### PR TITLE
fix a typo

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -178,7 +178,7 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `fqdn` - The fully qualified DNS name of this instance.
 
-* `network_interface.0.address` - The internal IP address of the instance.
+* `network_interface.0.ip_address` - The internal IP address of the instance.
 
 * `network_interface.0.nat_ip_address` - The external IP address of the instance.
 


### PR DESCRIPTION
Ran into this while using the official doc 

`' does not have attribute 'network_interface.0.address' for variable 'yandex_compute_instance.nat_gateway_az1.network_interface.0.address'
`

Turns out it has to be `ip_address` instead