### PR TITLE
remove a duplicated curly brace from the doc

### DIFF
--- a/website/docs/r/mdb_mongodb_cluster.html.markdown
+++ b/website/docs/r/mdb_mongodb_cluster.html.markdown
@@ -23,7 +23,6 @@ resource "yandex_vpc_subnet" "foo" {
   network_id     = "${yandex_vpc_network.foo.id}"
   v4_cidr_blocks = ["10.1.0.0/24"]
 }
-}
 
 resource "yandex_mdb_mongodb_cluster" "foo" {
   name        = "test"


### PR DESCRIPTION
When copy/pasting the example from the doc, I found a duplicated curly brace, so just removing it :)