### PR TITLE
make linter happy

### DIFF
--- a/yandex/base_lb_test.go
+++ b/yandex/base_lb_test.go
@@ -117,11 +117,7 @@ func getSubnetIPMap(instanceNames []string) (map[string][]string, error) {
 		}
 		subnetID := ifs[0].GetSubnetId()
 		address := ifs[0].GetPrimaryV4Address().GetAddress()
-		if _, ok := result[subnetID]; ok {
-			result[subnetID] = append(result[subnetID], address)
-		} else {
-			result[subnetID] = []string{address}
-		}
+		result[subnetID] = append(result[subnetID], address)
 	}
 
 	return result, nil

--- a/yandex/config_test.go
+++ b/yandex/config_test.go
@@ -117,8 +117,8 @@ func (s *userAgentMockServerAPIEndpoint) List(ctx context.Context, r *endpoint.L
 func localListener(t *testing.T) net.Listener {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
-		l, err = net.Listen("tcp6", "[::1]:0")
-		t.Fatal(err, "failed to listen on a any port")
+		_, err = net.Listen("tcp6", "[::1]:0")
+		t.Fatal(err, "failed to listen on an any port")
 	}
 	return l
 }

--- a/yandex/data_source_yandex_iam_policy_test.go
+++ b/yandex/data_source_yandex_iam_policy_test.go
@@ -65,7 +65,7 @@ func testPolicyUnmarshal(n string) resource.TestCheckFunc {
 }
 
 func testAccDataSourceYandexIAMPolicy() string {
-	return fmt.Sprintf(`
+	return `
 data "yandex_iam_policy" "foo" {
   binding {
     role = "editor"
@@ -85,11 +85,11 @@ data "yandex_iam_policy" "foo" {
     ]
   }
 }
-`)
+`
 }
 
 func testAccDataSourceYandexIAMPolicy_invalidConfig() string {
-	return fmt.Sprintf(`
+	return `
 data "yandex_iam_policy" "foo" {
   binding {
     role = "role_editor"
@@ -108,5 +108,5 @@ data "yandex_iam_policy" "foo" {
     ]
   }
 }
-`)
+`
 }

--- a/yandex/resource_yandex_compute_disk_test.go
+++ b/yandex/resource_yandex_compute_disk_test.go
@@ -306,6 +306,7 @@ resource "yandex_compute_disk" "seconddisk" {
 `, firstDiskName, snapshotName, secondDiskName)
 }
 
+//nolint:unused
 func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {
 	return fmt.Sprintf(`
 data "yandex_compute_image" "ubuntu" {

--- a/yandex/resource_yandex_compute_instance_test.go
+++ b/yandex/resource_yandex_compute_instance_test.go
@@ -1167,6 +1167,7 @@ func testAccCheckComputeInstanceHasNatAddress(instance *compute.Instance) resour
 	}
 }
 
+//nolint:unused
 func testAccCheckComputeInstanceHasMultiNic(instance *compute.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if len(instance.NetworkInterfaces) < 2 {
@@ -1783,6 +1784,7 @@ resource "yandex_vpc_subnet" "inst-test-subnet" {
 `, disk, instance)
 }
 
+//nolint:unused
 func testAccComputeInstance_attachedDisk_modeRo(disk, instance string) string {
 	return fmt.Sprintf(`
 data "yandex_compute_image" "ubuntu" {
@@ -2063,6 +2065,7 @@ resource "yandex_vpc_subnet" "inst-test-subnet" {
 `, instance, diskType)
 }
 
+//nolint:unused
 func testAccComputeInstance_subnet_auto(instance string) string {
 	return fmt.Sprintf(`
 data "yandex_compute_image" "u_image" {
@@ -2208,6 +2211,7 @@ resource "yandex_compute_instance" "foobar" {
 `, acctest.RandString(10), acctest.RandString(10), instance, address)
 }
 
+//nolint:unused
 func testAccComputeInstance_multiNic(instance, network, subnetwork string) string {
 	return fmt.Sprintf(`
 data "yandex_compute_image" "ubuntu" {

--- a/yandex/resource_yandex_function_trigger_test.go
+++ b/yandex/resource_yandex_function_trigger_test.go
@@ -305,6 +305,7 @@ resource "yandex_function_trigger" "test-trigger" {
 	`, regName, devName, name)
 }
 
+//nolint:unused
 func testYandexFunctionTriggerMessageQueue(name, queueID, serviceAccountID string) string {
 	return fmt.Sprintf(`
 resource "yandex_function_trigger" "test-trigger" {

--- a/yandex/resource_yandex_mdb_clickhouse_cluster_test.go
+++ b/yandex/resource_yandex_mdb_clickhouse_cluster_test.go
@@ -283,6 +283,7 @@ func testAccCheckMDBClickHouseClusterHasResources(r *clickhouse.Cluster, resourc
 	}
 }
 
+//nolint:unused
 func testAccCheckMDBClickHouseClusterHasShards(r *clickhouse.Cluster, shards []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
@@ -636,6 +637,7 @@ resource "yandex_mdb_clickhouse_cluster" "foo" {
 `, name, desc)
 }
 
+//nolint:unused
 func testAccMDBClickHouseClusterConfigSharded(name, desc string) string {
 	return fmt.Sprintf(clickHouseVPCDependencies+`
 resource "yandex_mdb_clickhouse_cluster" "bar" {
@@ -681,6 +683,7 @@ resource "yandex_mdb_clickhouse_cluster" "bar" {
 `, name, desc)
 }
 
+//nolint:unused
 func testAccMDBClickHouseClusterConfigShardedUpdated(name, desc string) string {
 	return fmt.Sprintf(clickHouseVPCDependencies+`
 resource "yandex_mdb_clickhouse_cluster" "bar" {

--- a/yandex/resource_yandex_resourcemanager_folder_iam_policy_test.go
+++ b/yandex/resource_yandex_resourcemanager_folder_iam_policy_test.go
@@ -157,7 +157,7 @@ func testAccFolderIamPolicy_basic(cloudID, folderID string, policy *Policy) stri
 	for role, members := range rolesMap {
 		bindingBuffer.WriteString("binding {\n")
 		bindingBuffer.WriteString(fmt.Sprintf("role = \"%s\"\n", role))
-		bindingBuffer.WriteString(fmt.Sprintf("members = [\n"))
+		bindingBuffer.WriteString("members = [\n")
 		for m := range members {
 			bindingBuffer.WriteString(fmt.Sprintf("\"%s\",\n", m))
 		}


### PR DESCRIPTION
Some functions marked as 'nolint:unused' as they saw as unreachable due to 't.Skip()' in primary test functions.