### PR TITLE
Few fixes for docs formatting

### DIFF
--- a/website/docs/d/datasource_compute_instance.html.markdown
+++ b/website/docs/d/datasource_compute_instance.html.markdown
@@ -66,8 +66,7 @@ The `boot_disk` block supports:
     under `/dev/disk/by-id/`.
 * `mode` - Access to the disk resource. By default a disk is attached in `READ_WRITE` mode.
 * `disk_id` - ID of the attached disk.
-* `initialize_params` - Parameters used for creating a disk alongside the instance.
-    The structure is documented below.
+* `initialize_params` - Parameters used for creating a disk alongside the instance. The structure is documented below.
 
 The `initialize_params` block supports:
 

--- a/website/docs/d/datasource_compute_instance_group.html.markdown
+++ b/website/docs/d/datasource_compute_instance_group.html.markdown
@@ -34,38 +34,22 @@ The following arguments are supported:
 * `description` - A description of the instance group.
 * `folder_id` - The ID of the folder that the instance group belongs to.
 * `labels` - A set of key/value label pairs to assign to the instance group.
-* `health_check` - Health check specification.
+* `health_check` - Health check specification. The structure is documented below.
 
-The structure is documented below.
+* `load_balancer` - Load balancing specification. The structure is documented below.
 
-* `load_balancer` - Load balancing specification.
+* `deploy_policy` - The deployment policy of the instance group. The structure is documented below.
 
-The structure is documented below.
+* `allocation_policy` - The allocation policy of the instance group by zone and region. The structure is documented below.
 
-* `deploy_policy` - The deployment policy of the instance group.
+* `instances` - A list of instances in the specified instance group. The structure is documented below.
 
-The structure is documented below.
-
-* `allocation_policy` - The allocation policy of the instance group by zone and region.
-
-The structure is documented below.
-
-* `instances` - A list of instances in the specified instance group.
-
-The structure is documented below.
-
-* `instance_template` - The instance template that the instance group belongs to.
-
-The structure is documented below.
+* `instance_template` - The instance template that the instance group belongs to. The structure is documented below.
 
 * `service_account_id` - The ID of the service account authorized for this instance group. 
-* `scale_policy` - The scaling policy of the instance group.
+* `scale_policy` - The scaling policy of the instance group. The structure is documented below.
 
-The structure is documented below.
-
-* `load_balancer_state` - Information about which entities can be attached to this load balancer.
-
-The structure is documented below.
+* `load_balancer_state` - Information about which entities can be attached to this load balancer. The structure is documented below.
 
 * `created_at` - The instance group creation timestamp.
 
@@ -84,13 +68,9 @@ The `load_balancer_state` block supports:
 
 The `scale_policy` block supports:
 
-* `fixed_scale` - The fixed scaling policy of the instance group.
+* `fixed_scale` - The fixed scaling policy of the instance group. The structure is documented below.
 
-The structure is documented below.
-
-* `auto_scale` - The auto scaling policy of the instance group.
-
-The structure is documented below.
+* `auto_scale` - The auto scaling policy of the instance group. The structure is documented below.
 
 ---
 
@@ -121,9 +101,7 @@ will not decrease even if the average load falls below the value of `cpu_utiliza
 
 * `cpu_utilization_target` - Target CPU load level.
 
-* `custom_rule` - A list of custom rules.
-
-The structure is documented below.
+* `custom_rule` - A list of custom rules. The structure is documented below.
 
 ---
 
@@ -156,16 +134,11 @@ The `instance_template` block supports:
 * `resources.0.cores` - Number of CPU cores allocated to the instance.
 * `resources.0.core_fraction` - Baseline core performance as a percent.
 * `resources.0.gpus` - Number of GPU cores allocated to the instance.
-* `scheduling_policy` - The scheduling policy for the instance.
-The structure is documented below.
-* `network_interface` - An array with the network interfaces that will be attached to the instance.
-The structure is documented below.
-* `secondary_disk` - An array with the secondary disks that will be attached to the instance.
-The structure is documented below.
-* `boot_disk` - The specifications for boot disk that will be attached to the instance.
-The structure is documented below.
-* `network_settings` - Network acceleration settings.
-The structure is documented below.
+* `scheduling_policy` - The scheduling policy for the instance. The structure is documented below.
+* `network_interface` - An array with the network interfaces that will be attached to the instance. The structure is documented below.
+* `secondary_disk` - An array with the secondary disks that will be attached to the instance. The structure is documented below.
+* `boot_disk` - The specifications for boot disk that will be attached to the instance. The structure is documented below.
+* `network_settings` - Network acceleration settings. The structure is documented below.
 * `name` - Name template of the instance.
 * `hostname` - Hostname temaplate for the instance.
 
@@ -175,8 +148,7 @@ The `boot_disk` block supports:
 
 * `device_name` - This value can be used to reference the device under `/dev/disk/by-id/`.
 * `mode` - The access mode to the disk resource. By default a disk is attached in `READ_WRITE` mode.
-* `initialize_params` - The parameters used for creating a disk alongside the instance.
-The structure is documented below.
+* `initialize_params` - The parameters used for creating a disk alongside the instance. The structure is documented below.
 
 ---
 
@@ -194,8 +166,7 @@ The `secondary_disk` block supports:
 
 * `device_name` - This value can be used to reference the device under `/dev/disk/by-id/`.
 * `mode` - The access mode to the disk resource. By default a disk is attached in `READ_WRITE` mode.
-* `initialize_params` - The parameters used for creating a disk alongside the instance.
-The structure is documented below.
+* `initialize_params` - The parameters used for creating a disk alongside the instance. The structure is documented below.
 
 ---
 
@@ -232,8 +203,7 @@ The `instances` block supports:
 * `status` - The status of the instance.
 * `status_message` - The status message of the instance.
 * `zone_id` - The ID of the availability zone where the instance resides.
-* `network_interface` - An array with the network interfaces attached to the managed instance.
-The structure is documented below.
+* `network_interface` - An array with the network interfaces attached to the managed instance. The structure is documented below.
 * `status_changed_at` -The timestamp when the status of the managed instance was last changed.
 
 ---
@@ -286,10 +256,8 @@ The `health_check` block supports:
 * `timeout` - Timeout for the managed instance to return a response for the health check in seconds.
 * `healthy_threshold` - The number of successful health checks before the managed instance is declared healthy.
 * `unhealthy_threshold` - The number of failed health checks before the managed instance is declared unhealthy.
-* `tcp_options` - TCP check options.
-The structure is documented below.
-* `http_options` - HTTP check options.
-The structure is documented below.
+* `tcp_options` - TCP check options. The structure is documented below.
+* `http_options` - HTTP check options. The structure is documented below.
 
 ---
 

--- a/website/docs/d/datasource_compute_instance_group.html.markdown
+++ b/website/docs/d/datasource_compute_instance_group.html.markdown
@@ -72,6 +72,7 @@ The structure is documented below.
 * `variables` - A set of key/value  variables pairs to assign to the instance group.
 
 * `status` - Status of the instance group.
+
 ---
 
 The `load_balancer_state` block supports:

--- a/website/docs/d/datasource_kubernetes_cluster.html.markdown
+++ b/website/docs/d/datasource_kubernetes_cluster.html.markdown
@@ -53,9 +53,7 @@ to access Container Registry or to push node logs and metrics.
 
 * `release_channel` - Cluster release channel.
 
-* `master` - Kubernetes master configuration options.
-
-The structure is documented below.
+* `master` - Kubernetes master configuration options. The structure is documented below.
 
 * `created_at` - The Kubernetes cluster creation timestamp.
 * `status` - Status of the Kubernetes cluster.
@@ -72,17 +70,11 @@ The `master` block supports:
 * `version` - Version of Kubernetes master.
 * `public_ip` - Boolean flag. When `true`, Kubernetes master have visible ipv4 address.
 
-* `maintenance_policy` - Maintenance policy for Kubernetes master.
+* `maintenance_policy` - Maintenance policy for Kubernetes master. The structure is documented below.
 
-The structure is documented below.
+* `zonal` - Information about cluster zonal master. The structure is documented below.
 
-* `zonal` - Information about cluster zonal master.
-
-The structure is documented below.
-
-* `regional` - Information about cluster regional master.
-
-The structure is documented below.
+* `regional` - Information about cluster regional master. The structure is documented below.
 
 * `internal_v4_address` - An IPv4 internal network address that is assigned to the master.
 * `external_v4_address` - An IPv4 external network address that is assigned to the master.
@@ -90,9 +82,7 @@ The structure is documented below.
 * `external_v4_endpoint` - External endpoint that can be used to access Kubernetes cluster API from the internet (outside of the cloud).
 * `cluster_ca_certificate` - PEM-encoded public certificate that is the root of trust for the Kubernetes cluster.  
 
-* `version_info` - Information about cluster version.
-
-The structure is documented below.
+* `version_info` - Information about cluster version. The structure is documented below.
 
 ---
 

--- a/website/docs/d/datasource_kubernetes_node_group.html.markdown
+++ b/website/docs/d/datasource_kubernetes_node_group.html.markdown
@@ -43,23 +43,15 @@ The following arguments are supported:
 * `created_at` - The Kubernetes node group creation timestamp.
 * `status` - Status of the Kubernetes node group.
 
-* `instance_template` - Template used to create compute instances in this Kubernetes node group.
+* `instance_template` - Template used to create compute instances in this Kubernetes node group. The structure is documented below.
 
-The structure is documented below.
+* `scale_policy` - Scale policy of the node group. The structure is documented below.
 
-* `scale_policy` - Scale policy of the node group.
- 
-The structure is documented below.
-
-* `allocation_policy` - This argument specify subnets (zones), that will be used by node group compute instances.
-
-The structure is documented below.
+* `allocation_policy` - This argument specify subnets (zones), that will be used by node group compute instances. The structure is documented below.
 
 * `instance_group_id` - ID of instance group that is used to manage this Kubernetes node group.
 
-* `maintenance_policy` - Information about maintenance policy for this Kubernetes node group.
-
-The structure is documented below.
+* `maintenance_policy` - Information about maintenance policy for this Kubernetes node group. The structure is documented below.
 
 * `node_labels` - A set of key/value label pairs, that are assigned to all the nodes of this Kubernetes node group.
 
@@ -67,13 +59,9 @@ The structure is documented below.
 
 * `allowed_unsafe_sysctls` - A list of allowed unsafe sysctl parameters for this node group. For more details see [documentation](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/).
 
-* `version_info` - Information about Kubernetes node group version.
+* `version_info` - Information about Kubernetes node group version. The structure is documented below.
 
-The structure is documented below.
-
-* `deploy_policy` - Deploy policy of the node group.
-
-The structure is documented below.
+* `deploy_policy` - Deploy policy of the node group. The structure is documented below.
 
 ---
 
@@ -87,13 +75,9 @@ The `instance_template` block supports:
 * `resources.0.cores` - Number of CPU cores allocated to the instance.
 * `resources.0.core_fraction` - Baseline core performance as a percent.
 
-* `boot_disk` - The specifications for boot disks that will be attached to the instance.
+* `boot_disk` - The specifications for boot disks that will be attached to the instance. The structure is documented below.
 
-The structure is documented below.
-
-* `scheduling_policy` - The scheduling policy for the instances in node group.
-
-The structure is documented below.
+* `scheduling_policy` - The scheduling policy for the instances in node group. The structure is documented below.
 
 ---
 
@@ -135,9 +119,7 @@ The `auto_scale` block supports:
 
 The `allocation_policy` block supports:
 
-* `location` - Repeated field, that specify subnets (zones), that will be used by node group compute instances.
-
-The structure is documented below.   
+* `location` - Repeated field, that specify subnets (zones), that will be used by node group compute instances. The structure is documented below.   
 
 ---
 

--- a/website/docs/d/datasource_vpc_security_group.html.markdown
+++ b/website/docs/d/datasource_vpc_security_group.html.markdown
@@ -38,14 +38,8 @@ The following attribute is exported:
 * `network_id` - ID of the network this security group belongs to.
 * `folder_id` - ID of the folder this security group belongs to.
 * `labels` - Labels to assign to this security group.
-* `ingress` - A list of ingress rules.
-
-The structure is documented below.
-
-* `egress` - A list of egress rules.
-
-The structure is documented below.
-
+* `ingress` - A list of ingress rules. The structure is documented below.
+* `egress` - A list of egress rules. The structure is documented below.
 * `status` - Status of this security group.
 * `created_at` - Creation timestamp of this security group.
 

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -52,11 +52,9 @@ resource "yandex_vpc_subnet" "foo" {
 
 The following arguments are supported:
 
-* `resources` - (Required) Compute resources that are allocated for the instance.
-    The structure is documented below.
+* `resources` - (Required) Compute resources that are allocated for the instance. The structure is documented below.
 
-* `boot_disk` - (Required) The boot disk for the instance.
-    The structure is documented below.
+* `boot_disk` - (Required) The boot disk for the instance. The structure is documented below.
 
 * `network_interface` - (Required) Networks to attach to the instance. This can
     be specified multiple times. The structure is documented below.
@@ -120,8 +118,7 @@ The `boot_disk` block supports:
     `yandex_compute_disk`) to attach as a boot disk.
 
 * `initialize_params` - (Optional) Parameters for a new disk that will be created
-    alongside the new instance. Either `initialize_params` or `disk_id` must be set.
-    The structure is documented below.
+    alongside the new instance. Either `initialize_params` or `disk_id` must be set. The structure is documented below.
 
 ~> **NOTE:** Either `initialize_params` or `disk_id` must be specified.
 

--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -78,27 +78,21 @@ The following arguments are supported:
 
 * `folder_id` - (Required) The ID of the folder that the resources belong to.
 
-* `scale_policy` - (Required) The scaling policy of the instance group.
-The structure is documented below.
+* `scale_policy` - (Required) The scaling policy of the instance group. The structure is documented below.
 
-* `deploy_policy` - (Required) The deployment policy of the instance group.
-The structure is documented below.
+* `deploy_policy` - (Required) The deployment policy of the instance group. The structure is documented below.
 
 * `service_account_id` - (Required) The ID of the service account authorized for this instance group.
 
-* `instance_template` - (Required) The template for creating new instances.
-The structure is documented below.
+* `instance_template` - (Required) The template for creating new instances. The structure is documented below.
 
-* `allocation_policy` - (Required) The allocation policy of the instance group by zone and region.
-The structure is documented below.
+* `allocation_policy` - (Required) The allocation policy of the instance group by zone and region. The structure is documented below.
 
 * `name` - (Optional) The name of the instance group.
 
-* `health_check` - (Optional) Health check specifications.
-The structure is documented below.
+* `health_check` - (Optional) Health check specifications. The structure is documented below.
 
-* `load_balancer` - (Optional) Load balancing specifications.
-The structure is documented below.
+* `load_balancer` - (Optional) Load balancing specifications. The structure is documented below.
 
 * `description` - (Optional) A description of the instance group.
 
@@ -128,11 +122,9 @@ The `health_check` block supports:
 
 * `unhealthy_threshold` - (Optional) The number of failed health checks before the managed instance is declared unhealthy.
 
-* `tcp_options` - (Optional) TCP check options.
-The structure is documented below.
+* `tcp_options` - (Optional) TCP check options. The structure is documented below.
 
-* `http_options` - (Optional) HTTP check options.
-The structure is documented below.
+* `http_options` - (Optional) HTTP check options. The structure is documented below.
 
 ---
 
@@ -158,17 +150,13 @@ The `allocation_policy` block supports:
 
 The `instance_template` block supports:
 
-* `boot_disk` - (Required) Boot disk specifications for the instance.
-The structure is documented below.
+* `boot_disk` - (Required) Boot disk specifications for the instance. The structure is documented below.
 
-* `resources` - (Required) Compute resource specifications for the instance.
-The structure is documented below.
+* `resources` - (Required) Compute resource specifications for the instance. The structure is documented below.
 
-* `network_interface` - (Required) Network specifications for the instance. This can be used multiple times for adding multiple interfaces.
-The structure is documented below.
+* `network_interface` - (Required) Network specifications for the instance. This can be used multiple times for adding multiple interfaces. The structure is documented below.
 
-* `scheduling_policy` - (Optional) The scheduling policy configuration.
-The structure is documented below.
+* `scheduling_policy` - (Optional) The scheduling policy configuration. The structure is documented below.
 
 * `description` - (Optional) A description of the instance.
 
@@ -178,8 +166,7 @@ The structure is documented below.
 
 * `platform_id` - (Optional) The ID of the hardware platform configuration for the instance. The default is 'standard-v1'.
 
-* `secondary_disk` - (Optional) A list of disks to attach to the instance. 
-The structure is documented below.
+* `secondary_disk` - (Optional) A list of disks to attach to the instance. The structure is documented below.
 
 * `service_account_id` - (Optional) The ID of the service account authorized for this instance.
 
@@ -212,8 +199,7 @@ The `secondary_disk` block supports:
 
 * `mode` - (Required) The access mode to the disk resource. By default a disk is attached in `READ_WRITE` mode.
 
-* `initialize_params` - (Required) Parameters used for creating a disk alongside the instance.
-The structure is documented below.
+* `initialize_params` - (Required) Parameters used for creating a disk alongside the instance. The structure is documented below.
 
 - - -
 * `device_name` - (Optional) This value can be used to reference the device under `/dev/disk/by-id/`.
@@ -267,8 +253,7 @@ The `boot_disk` block supports:
 
 * `mode` - (Required) The access mode to the disk resource. By default a disk is attached in `READ_WRITE` mode.
 
-* `initialize_params` - (Required) Parameters for creating a disk alongside the instance.
-The structure is documented below.
+* `initialize_params` - (Required) Parameters for creating a disk alongside the instance. The structure is documented below.
 
 - - -
 * `device_name` - (Optional) This value can be used to reference the device under `/dev/disk/by-id/`.
@@ -312,11 +297,9 @@ has elapsed and all health checks are passed.
 
 The `scale_policy` block supports:
 
-* `fixed_scale` - (Optional) The fixed scaling policy of the instance group.
-The structure is documented below.
+* `fixed_scale` - (Optional) The fixed scaling policy of the instance group. The structure is documented below.
 
-* `auto_scale` - (Optional) The auto scaling policy of the instance group.
-The structure is documented below.
+* `auto_scale` - (Optional) The auto scaling policy of the instance group. The structure is documented below.
 
 ~> **NOTE:** Either `fixed_scale` or `auto_scale` must be specified.
 
@@ -349,8 +332,7 @@ traffic is fed to the virtual machine, but load metrics are not taken into accou
 an instance group can reduce the number of virtual machines in the group. During this time, the group
 will not decrease even if the average load falls below the value of `cpu_utilization_target`.
 
-* `custom_rule` - (Optional) A list of custom rules.
-The structure is documented below.
+* `custom_rule` - (Optional) A list of custom rules. The structure is documented below.
 
 ---
 

--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -105,6 +105,7 @@ The structure is documented below.
 * `labels` - (Optional) A set of key/value label pairs to assign to the instance group.
 
 * `variables` - (Optional) A set of key/value  variables pairs to assign to the instance group.
+
 ---
 
 The `load_balancer` block supports:
@@ -204,6 +205,7 @@ In order to be unique it must contain at least on of instance unique placeholder
 Example: my-instance-{instance.index}   
 If not set, `name` value will be used   
 It may also contain another placeholders, see metadata doc for full list.
+
 ---
 
 The `secondary_disk` block supports:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -147,6 +147,7 @@ to access Container Registry or to push node logs and metrics.
 
 **Note**: When access rights for `service_account_id` or `node_service_account_id` are provided using terraform resources,
 it is necessary to add dependency on these access resources to cluster config:
+
 ```hcl
 depends_on = [
   "yandex_resourcemanager_folder_iam_member.ServiceAccountResourceName",

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -163,9 +163,7 @@ that will cause problems for cluster and related node group deletion.
 
 * `kms_provider` - (Optional) cluster KMS provider parameters.
 
-* `master` - Kubernetes master configuration options.
-
-The structure is documented below.
+* `master` - Kubernetes master configuration options. The structure is documented below.
 
 ## Attributes Reference
 
@@ -184,21 +182,13 @@ The `master` block supports:
 * `maintenance_policy` - (Optional) (Computed) Maintenance policy for Kubernetes master.
 If policy is omitted, automatic revision upgrades of the kubernetes master are enabled and could happen at any time.
 Revision upgrades are performed only within the same minor version, e.g. 1.13.
-Minor version upgrades (e.g. 1.13->1.14) should be performed manually.
+Minor version upgrades (e.g. 1.13->1.14) should be performed manually. The structure is documented below.
 
-The structure is documented below.
+* `zonal` - (Optional) Initialize parameters for Zonal Master (single node master). The structure is documented below.
 
-* `zonal` - (Optional) Initialize parameters for Zonal Master (single node master).
+* `regional` - (Optional) Initialize parameters for Regional Master (highly available master). The structure is documented below.
 
-The structure is documented below.
-
-* `regional` - (Optional) Initialize parameters for Regional Master (highly available master).
-
-The structure is documented below.
-
-* `version_info` - (Computed) Information about cluster version.
-
-The structure is documented below.
+* `version_info` - (Computed) Information about cluster version. The structure is documented below.
 
 * `internal_v4_address` - (Computed) An IPv4 internal network address that is assigned to the master.
 * `external_v4_address` - (Computed) An IPv4 external network address that is assigned to the master.
@@ -230,9 +220,7 @@ The `zonal` block supports:
 The `regional` block supports:
 
 * `region` - (Required) Name of availability region (e.g. "ru-central1"), where master instances will be allocated.
-* `location` - Array of locations, where master instances will be allocated.
-
-The structure is documented below.
+* `location` - Array of locations, where master instances will be allocated. The structure is documented below.
 
 ---
 

--- a/website/docs/r/kubernetes_node_group.html.markdown
+++ b/website/docs/r/kubernetes_node_group.html.markdown
@@ -83,26 +83,18 @@ The following arguments are supported:
 * `description` - (Optional) A description of the Kubernetes node group.
 * `labels` - (Optional) A set of key/value label pairs assigned to the Kubernetes node group.
 * `version` - (Optional) Version of Kubernetes that will be used for Kubernetes node group.
-* `instance_template` - (Required) Template used to create compute instances in this Kubernetes node group.
+* `instance_template` - (Required) Template used to create compute instances in this Kubernetes node group. The structure is documented below.
 
-The structure is documented below.
+* `scale_policy` - (Required) Scale policy of the node group. The structure is documented below.
 
-* `scale_policy` - (Required) Scale policy of the node group.
- 
-The structure is documented below.
-
-* `allocation_policy` - This argument specify subnets (zones), that will be used by node group compute instances.
-
-The structure is documented below.
+* `allocation_policy` - This argument specify subnets (zones), that will be used by node group compute instances. The structure is documented below.
 
 * `instance_group_id` - (Computed) ID of instance group that is used to manage this Kubernetes node group.
 
 * `maintenance_policy` - (Optional) (Computed) Maintenance policy for this Kubernetes node group.
 If policy is omitted, automatic revision upgrades are enabled and could happen at any time.
 Revision upgrades are performed only within the same minor version, e.g. 1.13.
-Minor version upgrades (e.g. 1.13->1.14) should be performed manually.
-
-The structure is documented below.
+Minor version upgrades (e.g. 1.13->1.14) should be performed manually. The structure is documented below.
 
 * `node_labels` - (Optional, Forces new resource) A set of key/value label pairs, that are assigned to all the nodes of this Kubernetes node group.
 
@@ -110,13 +102,9 @@ The structure is documented below.
 
 * `allowed_unsafe_sysctls` - (Optional, Forces new resource) A list of allowed unsafe sysctl parameters for this node group. For more details see [documentation](https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/).
 
-* `version_info` - (Computed) Information about Kubernetes node group version.
+* `version_info` - (Computed) Information about Kubernetes node group version. The structure is documented below.
 
-The structure is documented below.
-
-* `deploy_policy` - Deploy policy of the node group.
-
-The structure is documented below.
+* `deploy_policy` - Deploy policy of the node group. The structure is documented below.
 
 ---
 
@@ -129,13 +117,9 @@ The `instance_template` block supports:
 * `resources.0.cores` - Number of CPU cores allocated to the instance.
 * `resources.0.core_fraction` - Baseline core performance as a percent.
 
-* `boot_disk` - The specifications for boot disks that will be attached to the instance.
+* `boot_disk` - The specifications for boot disks that will be attached to the instance. The structure is documented below.
 
-The structure is documented below.
-
-* `scheduling_policy` - The scheduling policy for the instances in node group.
-
-The structure is documented below.
+* `scheduling_policy` - The scheduling policy for the instances in node group. The structure is documented below.
 
 
 ---
@@ -176,9 +160,7 @@ The `auto_scale` block supports:
 
 The `allocation_policy` block supports:
 
-* `location` - Repeated field, that specify subnets (zones), that will be used by node group compute instances.
-
-The structure is documented below.   
+* `location` - Repeated field, that specify subnets (zones), that will be used by node group compute instances. The structure is documented below.   
 
 ---
 

--- a/website/docs/r/lb_network_load_balancer.html.markdown
+++ b/website/docs/r/lb_network_load_balancer.html.markdown
@@ -59,8 +59,7 @@ The default is 'ru-central1'.
 
 * `attached_target_group` - (Optional) An AttachedTargetGroup resource. The structure is documented below.
 
-* `listener` - (Optional) Listener specification that will be used by a network load balancer. 
-The structure is documented below.
+* `listener` - (Optional) Listener specification that will be used by a network load balancer. The structure is documented below.
 
 ---
 
@@ -68,8 +67,7 @@ The `attached_target_group` block supports:
 
 * `target_group_id` - (Required) ID of the target group.
 
-* `healthcheck` - (Required) A HealthCheck resource. 
-The structure is documented below.
+* `healthcheck` - (Required) A HealthCheck resource. The structure is documented below.
 
 ---
 

--- a/website/docs/r/vpc_security_group.html.markdown
+++ b/website/docs/r/vpc_security_group.html.markdown
@@ -68,9 +68,7 @@ The following arguments are supported:
 * `folder_id` (Optional) - ID of the folder this security group belongs to.
 * `labels` (Optional) - Labels to assign to this security group.
 * `ingress` (Optional) - A list of ingress rules.
-* `egress` (Optional) - A list of egress rules.
-
-The structure is documented below.
+* `egress` (Optional) - A list of egress rules. The structure is documented below.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Without changing a text of documentation - just few improvements in markdown layout.
PR fixes these cases:
1. Some list items became headings because of missing spaces. [Example](https://www.terraform.io/docs/providers/yandex/d/datasource_compute_instance_group.html#status-status-of-the-instance-group-).
2. "The structure is documented below." comment for list items broke list structure. [Example](https://www.terraform.io/docs/providers/yandex/d/datasource_compute_instance_group.html#health_check).
3. Code highlighting was turned off because missing space. [Example](https://www.terraform.io/docs/providers/yandex/r/kubernetes_cluster.html#node_service_account_id).