### PR TITLE
Added "host.role" attribute of yandex_mdb_postgresql_cluster (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 0.42.0 (Unreleased)
+
+ENHANCEMENTS:
+* mdb: add `role` attribute to `host` entity in `yandex_mdb_postgresql_cluster` resource and data source
+
 BUG FIXES:
 * compute: fix `secondary_disk` validation in `yandex_compute_instance_group` resource
 

--- a/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
+++ b/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
@@ -113,3 +113,4 @@ The `host` block supports:
 * `zone` - The availability zone where the PostgreSQL host will be created.
 * `subnet_id` - The ID of the subnet, to which the host belongs. The subnet must be a part of the network to which the cluster belongs.
 * `assign_public_ip` - Sets whether the host should get a public IP address on creation. Changing this parameter for an existing host is not supported at the moment
+* `role` - Role of the host in the cluster.

--- a/yandex/data_source_yandex_mdb_postgresql_cluster.go
+++ b/yandex/data_source_yandex_mdb_postgresql_cluster.go
@@ -188,6 +188,10 @@ func dataSourceYandexMDBPostgreSQLCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/yandex/data_source_yandex_mdb_postgresql_cluster_test.go
+++ b/yandex/data_source_yandex_mdb_postgresql_cluster_test.go
@@ -187,6 +187,10 @@ func testAccDataSourceMDBPGClusterAttributesCheck(datasourceName string, resourc
 				"host.0.zone",
 			},
 			{
+				"host.0.role",
+				"host.0.role",
+			},
+			{
 				"labels.%",
 				"labels.%",
 			},

--- a/yandex/mdb_postgresql_structures.go
+++ b/yandex/mdb_postgresql_structures.go
@@ -201,6 +201,7 @@ func flattenPGHosts(hs []*postgresql.Host) ([]map[string]interface{}, error) {
 		m["subnet_id"] = h.SubnetId
 		m["assign_public_ip"] = h.AssignPublicIp
 		m["fqdn"] = h.Name
+		m["role"] = h.Role.String()
 
 		out = append(out, m)
 	}

--- a/yandex/resource_yandex_mdb_postgresql_cluster.go
+++ b/yandex/resource_yandex_mdb_postgresql_cluster.go
@@ -255,6 +255,10 @@ func resourceYandexMDBPostgreSQLCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"role": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
It is needed to determine the master host to connect right after creation of managed pg cluster.