### PR TITLE
Increase default timeout from 5 to 10 minutes for compute instance and disk

### DIFF
--- a/yandex/resource_yandex_compute_disk.go
+++ b/yandex/resource_yandex_compute_disk.go
@@ -14,7 +14,7 @@ import (
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1"
 )
 
-const yandexComputeDiskDefaultTimeout = 5 * time.Minute
+const yandexComputeDiskDefaultTimeout = 10 * time.Minute
 
 func resourceYandexComputeDisk() *schema.Resource {
 	return &schema.Resource{

--- a/yandex/resource_yandex_compute_instance.go
+++ b/yandex/resource_yandex_compute_instance.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	yandexComputeInstanceDefaultTimeout       = 5 * time.Minute
+	yandexComputeInstanceDefaultTimeout       = 10 * time.Minute
 	yandexComputeInstanceDiskOperationTimeout = 1 * time.Minute
 )
 


### PR DESCRIPTION
In case, when compute instance is creating from snapshot creation time can be more than 5 minutes.
