### PR TITLE
Added attribute `token` to yandex_kubernetes_cluster

### DIFF
--- a/website/docs/d/datasource_kubernetes_cluster.html.markdown
+++ b/website/docs/d/datasource_kubernetes_cluster.html.markdown
@@ -63,6 +63,8 @@ to access Container Registry or to push node logs and metrics.
 
 * `kms_provider` - cluster KMS provider parameters.
 
+* `token` - Token used to authenticate to the cluster.
+
 ---
 
 The `master` block supports:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -172,6 +172,8 @@ that will cause problems for cluster and related node group deletion.
 * `status` - (Computed)Status of the Kubernetes cluster.
 * `health` - (Computed) Health of the Kubernetes cluster.
 * `created_at` - (Computed) The Kubernetes cluster creation timestamp.
+* `token` - (Computed) Token used to authenticate to the cluster.
+
 
 ---
 

--- a/yandex/data_source_yandex_kubernetes_cluster.go
+++ b/yandex/data_source_yandex_kubernetes_cluster.go
@@ -66,6 +66,11 @@ func dataSourceYandexKubernetesCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 			"master": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -252,6 +257,14 @@ func dataSourceYandexKubernetesClusterRead(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return fmt.Errorf("failed to fill Kubernetes cluster attributes: %v", err)
 	}
+
+	response, err := config.sdk.CreateIAMToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	token := response.GetIamToken()
+	d.Set("token", token)
 
 	return nil
 }

--- a/yandex/resource_yandex_kubernetes_cluster_test.go
+++ b/yandex/resource_yandex_kubernetes_cluster_test.go
@@ -566,6 +566,7 @@ func checkClusterAttributes(cluster *k8s.Cluster, info *resourceClusterInfo, rs 
 				"node_ipv4_cidr_mask_size", strconv.Itoa(int(cluster.GetIpAllocationPolicy().GetNodeIpv4CidrMaskSize()))),
 			resource.TestCheckResourceAttr(resourceFullName,
 				"service_ipv4_range", cluster.GetIpAllocationPolicy().GetServiceIpv4CidrBlock()),
+			resource.TestCheckResourceAttrSet(resourceFullName, "token"),
 		}
 
 		if info.policy != emptyMaintenancePolicy {


### PR DESCRIPTION
Now we have to run an external tool to authenticate to the Kubernetes cluster. I propose to request IAM token by cloud API while reading cluster resource in order to avoid extra forks.