### PR TITLE
Added datasource yandex_client_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.42.0 (Unreleased)
 
+FEATURES:
+* **New Data Source:** `yandex_client_config`
+
 ENHANCEMENTS:
 * mdb: add `role` attribute to `host` entity in `yandex_mdb_postgresql_cluster` resource and data source
 

--- a/website/docs/d/datasource_client_config.html.markdown
+++ b/website/docs/d/datasource_client_config.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "yandex"
+page_title: "Yandex: yandex_client_config"
+sidebar_current: "docs-yandex-datasource-client-config"
+description: |-
+  Get attributes used by provider to configure client connection.
+---
+
+# yandex\_client\_config
+
+Get attributes used by provider to configure client connection.
+
+## Example usage
+```hcl
+data "yandex_client_config" "client" {}
+
+data "yandex_kubernetes_cluster" "kubernetes" {
+  name = "kubernetes"
+}
+
+provider "kubernetes" {
+  load_config_file = false
+
+  host                   = data.yandex_kubernetes_cluster.kubernetes.master.0.external_v4_endpoint
+  cluster_ca_certificate = data.yandex_kubernetes_cluster.kubernetes.master.0.cluster_ca_certificate
+  token                  = data.yandex_client_config.client.iam_token
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `cloud_id` - The ID of the cloud that the provider is connecting to.
+* `folder_id` - The ID of the folder in which we operate.
+* `zone` - The default availability zone.
+* `iam_token` - A short-lived token that can be used for authentication in a Kubernetes cluster.

--- a/yandex/data_source_yandex_client_config.go
+++ b/yandex/data_source_yandex_client_config.go
@@ -1,0 +1,51 @@
+package yandex
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"strconv"
+)
+
+func dataSourceYandexClientConfig() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceYandexClientConfigRead,
+		Schema: map[string]*schema.Schema{
+			"cloud_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"folder_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iam_token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func dataSourceYandexClientConfigRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := config.Context()
+
+	response, err := config.sdk.CreateIAMToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	iamToken := response.GetIamToken()
+	d.Set("cloud_id", config.CloudID)
+	d.Set("folder_id", config.FolderID)
+	d.Set("zone", config.Zone)
+	d.Set("iam_token", iamToken)
+	d.SetId(strconv.Itoa(schema.HashString(fmt.Sprintf("%s:%s:%s:%s", config.CloudID, config.FolderID, config.Zone, iamToken))))
+
+	return nil
+}

--- a/yandex/data_source_yandex_client_config_test.go
+++ b/yandex/data_source_yandex_client_config_test.go
@@ -1,0 +1,32 @@
+package yandex
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"os"
+	"testing"
+)
+
+func TestAccDataSourceYandexClientConfig(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceYandexClientConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.yandex_client_config.config", "cloud_id", os.Getenv("YC_CLOUD_ID")),
+					resource.TestCheckResourceAttr("data.yandex_client_config.config", "folder_id", os.Getenv("YC_FOLDER_ID")),
+					resource.TestCheckResourceAttr("data.yandex_client_config.config", "zone", os.Getenv("YC_ZONE")),
+					resource.TestCheckResourceAttrSet("data.yandex_client_config.config", "iam_token"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceYandexClientConfig() string {
+	return `
+data "yandex_client_config" "config" {}
+`
+}

--- a/yandex/provider.go
+++ b/yandex/provider.go
@@ -127,6 +127,7 @@ func provider(emptyFolder bool) terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"yandex_client_config":            dataSourceYandexClientConfig(),
 			"yandex_container_registry":       dataSourceYandexContainerRegistry(),
 			"yandex_compute_disk":             dataSourceYandexComputeDisk(),
 			"yandex_compute_image":            dataSourceYandexComputeImage(),


### PR DESCRIPTION
Datasource for retrieveing an attributes used by provider to configure client connection and a temporary IAM token, which may be used for authentication to the Kubernetes cluster. Alternative to the solution proposed in #85.
