### PR TITLE
Allow empty "static_route" Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ ENHANCEMENTS:
 * some changes in security group resource
 
 BUG FIXES:
-* lb: fix modifying listener settings 
+* lb: fix modifying listener settings
+* vpc: `static_route` in `yandex_vpc_route_table` is optional now
 
 ## 0.43.0 (August 20, 2020)
 

--- a/yandex/resource_yandex_vpc_route_table.go
+++ b/yandex/resource_yandex_vpc_route_table.go
@@ -106,7 +106,7 @@ func resourceYandexVPCRouteTableCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error expanding labels while creating route table: %s", err)
 	}
 
-	staticRoutes, err := expandStaticRoutes(d)
+	staticRoutes, err := expandStaticRoutes(d.Get("static_route"))
 	if err != nil {
 		return fmt.Errorf("Error expanding static routes while creating route table: %s", err)
 	}


### PR DESCRIPTION
The "static_route" block is marked as optional. Unfortunately, a function that converts a set into a gRPC struct is not aware of that fact.