### PR TITLE
redis: fix example. config version is required

### DIFF
--- a/website/docs/r/mdb_redis_cluster.html.markdown
+++ b/website/docs/r/mdb_redis_cluster.html.markdown
@@ -23,6 +23,7 @@ resource "yandex_mdb_redis_cluster" "foo" {
 
   config {
     password = "your_password"
+    version  = "6.0"
   }
 
   resources {
@@ -55,6 +56,7 @@ resource "yandex_mdb_redis_cluster" "foo" {
   sharded     = true
 
   config {
+    version  = "6.0"
     password = "your_password"
   }
 


### PR DESCRIPTION
If we don't specify `version`

```
> tf plan

Error: Missing required argument

  on redis.tf line 7, in resource "yandex_mdb_redis_cluster" "dbre_test":
   7:   config {

The argument "version" is required, but no definition was found.

```