### PR TITLE
#MDB postgres user conn_limit v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 BUG FIXES:
 * mdb: fix setting of folder_id field for MongoDB cluster
 
+ENHANCEMENTS:
+* mdb: add `conn_limit` attribute to `user` entity in `yandex_mdb_postgresql_cluster` resource and data source
 
 ## 0.47.0 (November 10, 2020)
 BUG FIXES:

--- a/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
+++ b/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
@@ -89,6 +89,7 @@ The `user` block supports:
 * `permission` - Set of permissions granted to the user. The structure is documented below.
 * `login` - User's ability to login.
 * `grants` - List of the user's grants.
+* `conn_limit` - The maximum number of connections per user.
 
 The `permission` block supports:
 

--- a/website/docs/r/mdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/mdb_postgresql_cluster.html.markdown
@@ -38,6 +38,7 @@ resource "yandex_mdb_postgresql_cluster" "foo" {
   user {
     name     = "user_name"
     password = "your_password"
+    conn_limit = 50
     permission {
       database_name = "db_name"
     }
@@ -193,6 +194,8 @@ The `user` block supports:
 * `login` - (Optional) User's ability to login.
 
 * `permission` - (Optional) Set of permissions granted to the user. The structure is documented below.
+
+* `conn_limit` - (Optional) The maximum number of connections per user. (Default 50)
 
 The `permission` block supports:
 

--- a/yandex/data_source_yandex_mdb_postgresql_cluster.go
+++ b/yandex/data_source_yandex_mdb_postgresql_cluster.go
@@ -250,6 +250,10 @@ func dataSourceYandexMDBPostgreSQLCluster() *schema.Resource {
 								},
 							},
 						},
+						"conn_limit": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
 					},
 				},
 			},

--- a/yandex/mdb_postgresql_structures.go
+++ b/yandex/mdb_postgresql_structures.go
@@ -130,6 +130,8 @@ func flattenPGUser(u *postgresql.User) (map[string]interface{}, error) {
 
 	m["grants"] = u.Grants
 
+	m["conn_limit"] = u.ConnLimit
+
 	return m, nil
 }
 
@@ -323,6 +325,13 @@ func expandPGUser(m map[string]interface{}) (*postgresql.UserSpec, error) {
 
 	if v, ok := m["login"]; ok {
 		user.Login = &wrappers.BoolValue{Value: v.(bool)}
+	}
+
+	if v, ok := m["conn_limit"]; ok {
+		var connLimit = &wrappers.Int64Value{Value: int64(v.(int))}
+		if connLimit.GetValue() > 0 {
+			user.ConnLimit = connLimit
+		}
 	}
 
 	if v, ok := m["permission"]; ok {

--- a/yandex/resource_yandex_mdb_postgresql_cluster.go
+++ b/yandex/resource_yandex_mdb_postgresql_cluster.go
@@ -226,6 +226,11 @@ func resourceYandexMDBPostgreSQLCluster() *schema.Resource {
 								},
 							},
 						},
+						"conn_limit": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -865,6 +870,10 @@ func updatePGUser(ctx context.Context, config *Config, d *schema.ResourceData, u
 		"user.%d.permission": "permissions",
 		"user.%d.login":      "login",
 		"user.%d.grants":     "grants",
+	}
+
+	if user.user.ConnLimit != nil {
+		mdbPGUserUpdateFieldsMap["user.%d.conn_limit"] = "conn_limit"
 	}
 
 	onDone := []func(){}

--- a/yandex/resource_yandex_mdb_postgresql_cluster_test.go
+++ b/yandex/resource_yandex_mdb_postgresql_cluster_test.go
@@ -134,7 +134,7 @@ func TestAccMDBPostgreSQLCluster_full(t *testing.T) {
 					testAccCheckMDBPGClusterHasResources(&cluster, "s2.micro", "network-ssd", 19327352832),
 					testAccCheckMDBPGClusterHasPoolerConfig(&cluster, "TRANSACTION", false),
 					testAccCheckMDBPGClusterHasUsers(pgResource, map[string][]string{"alice": {"testdb", "newdb"}, "bob": {"newdb", "fornewuserdb"}}),
-					testAccCheckUnmodifiedUserSettings(pgResource),
+					testAccCheckConnLimitUpdateUserSettings(pgResource),
 					testAccCheckMDBPGClusterHasDatabases(pgResource, []string{"testdb", "newdb", "fornewuserdb"}),
 					testAccCheckCreatedAtAttr(pgResource),
 				),
@@ -315,7 +315,7 @@ var testAccMDBPGClusterConfigUpdatedCheckConnLimitMap = map[string]int64{
 	"alice": 42,
 }
 
-func testAccCheckUnmodifiedUserSettings(r string) resource.TestCheckFunc {
+func testAccCheckConnLimitUpdateUserSettings(r string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
 		if !ok {
@@ -594,10 +594,9 @@ resource "yandex_mdb_postgresql_cluster" "foo" {
   }
 
   user {
-    name     = "alice"
-    password = "mysecurepassword"
-
-	conn_limit = 42
+    name       = "alice"
+    password   = "mysecurepassword"
+    conn_limit = 42
 
     permission {
       database_name = "testdb"


### PR DESCRIPTION
add `conn_limit` attribute to `user` entity in `yandex_mdb_postgresql_cluster`