### PR TITLE
Update storage_bucket.markdown

### DIFF
--- a/website/docs/r/storage_bucket.markdown
+++ b/website/docs/r/storage_bucket.markdown
@@ -16,6 +16,8 @@ Allows management of [Yandex.Cloud Storage Bucket](https://cloud.yandex.com/docs
 
 ```hcl
 resource "yandex_storage_bucket" "test" {
+  access_key ="access_key_here"
+  secret_key ="secret_key_here"
   bucket = "tf-test-bucket"
 }
 ```

--- a/website/docs/r/storage_bucket.markdown
+++ b/website/docs/r/storage_bucket.markdown
@@ -19,7 +19,12 @@ resource "yandex_storage_bucket" "test" {
   access_key ="access_key_here"
   secret_key ="secret_key_here"
   bucket = "tf-test-bucket"
+resource "yandex_storage_bucket" "test" {
+  access_key = "access_key_here"
+  secret_key = "secret_key_here"
+  bucket     = "tf-test-bucket"
 }
+
 ```
 
 ### Static Website Hosting


### PR DESCRIPTION
Добавил в ключи в пример "Simple Private Bucket", т.к. на мой взгляд не очевидно, что token или service_account_key_file из радела конфигурации Yandex.Cloud provider недостаточно.