### PR TITLE
Increase limit for disk size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * dataproc: supported `security_group_ids`
 * add `dns_record`, `ipv6_dns_record` and `nat_dns_record` to `network_interface` entity in `yandex_compute_instance_group`
 * ydb: support for Yandex Database clusters
+* compute: increase disk size limit from 4096Gb to 8192Gb 
 
 ## 0.55.0 (April 1, 2021)
 FEATURES:

--- a/yandex/resource_yandex_compute_disk.go
+++ b/yandex/resource_yandex_compute_disk.go
@@ -435,9 +435,9 @@ func isDiskSizeDecreased(old, new, _ interface{}) bool {
 
 func validateDiskSize(v interface{}, _ string) (warnings []string, errors []error) {
 	value := v.(int)
-	if value < 0 || value > 4096 {
+	if value < 0 || value > 8192 {
 		errors = append(errors, fmt.Errorf(
-			"The `size` can only be between 0 and 4096"))
+			"The `size` can only be between 0 and 8192"))
 	}
 	return warnings, errors
 }


### PR DESCRIPTION
Веб-консоль и cli позволяют создавать диски до 8192Гб, думаю у tf должны быть аналогичные лимиты