### PR TITLE
Removed node group boot disk size validation

### DIFF
--- a/yandex/resource_yandex_kubernetes_node_group.go
+++ b/yandex/resource_yandex_kubernetes_node_group.go
@@ -91,7 +91,6 @@ func resourceYandexKubernetesNodeGroup() *schema.Resource {
 										Type:         schema.TypeInt,
 										Optional:     true,
 										Computed:     true,
-										ValidateFunc: validation.IntAtLeast(64),
 									},
 									"type": {
 										Type:     schema.TypeString,


### PR DESCRIPTION
Let's deprecate it in favor of Cloud API validations, which now allow for boot disks larger than 16Gb.