### PR TITLE
Fix DNS zone example name

### DIFF
--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -16,7 +16,7 @@ Manages a DNS Zone.
 resource "yandex_vpc_network" "foo" {}
 
 resource "yandex_dns_zone" "zone1" {
-  name        = "my_private_zone"
+  name        = "my-private-zone"
   description = "desc"
 
   labels = {


### PR DESCRIPTION
Applying name from examples causes an error: `- name: Field does not match the pattern /|[a-z]([-a-z0-9]{0,61}[a-z0-9])?/`.