### PR TITLE
change version for cluster to 1.17

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -21,7 +21,7 @@ resource "yandex_kubernetes_cluster" "zonal_cluster_resource_name" {
   network_id = "${yandex_vpc_network.network_resource_name.id}"
 
   master {
-    version = "1.15"
+    version = "1.17"
     zonal {
       zone      = "${yandex_vpc_subnet.subnet_resource_name.zone}"
       subnet_id = "${yandex_vpc_subnet.subnet_resource_name.id}"

--- a/website/docs/r/kubernetes_node_group.html.markdown
+++ b/website/docs/r/kubernetes_node_group.html.markdown
@@ -18,7 +18,7 @@ resource "yandex_kubernetes_node_group" "my_node_group" {
   cluster_id  = "${yandex_kubernetes_cluster.my_cluster.id}"
   name        = "name"
   description = "description"
-  version     = "1.14"
+  version     = "1.17"
 
   labels = {
     "key" = "value"


### PR DESCRIPTION
If use version 1.15, then get error
```
Precondition failure: version is deprecated for cluster: version 1.15 is deprecated for this release channel
```