### PR TITLE
Add 'folders' attribute to Cloud data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.65.0 (Unreleased)
 FEATURES:
 * mdb: support Schema Registry in `yandex_mdb_kafka_cluster`
+* resourcemanager: data source `yandex_resourcemanager_cloud` now provides `folders` attribute
 
 FEATURES:
 * **New Resource:** `yandex_kms_symmetric_key_iam_binding`

--- a/website/docs/d/datasource_resourcemanager_cloud.html.markdown
+++ b/website/docs/d/datasource_resourcemanager_cloud.html.markdown
@@ -39,3 +39,4 @@ The following attributes are returned:
 * `name` - Name of the cloud.
 * `description` - Description of the cloud.
 * `created_at` - Cloud creation timestamp.
+* `folders` - List of folders in the cloud


### PR DESCRIPTION
Additional `yandex_resourcemanager_cloud` data source attribute
```tf
 folders = [
   {
     folder_id = "06nur34....."
     name      = "some_name"
   },
   {
     folder_id = "8a8i9ag....."
     name      = "some_name2"
   },
```