### PR TITLE
Add missed member type to `function_iam_binding` doc

### DIFF
--- a/website/docs/r/function_iam_binding.html.markdown
+++ b/website/docs/r/function_iam_binding.html.markdown
@@ -30,4 +30,5 @@ The following arguments are supported:
 * `members` - (Required) Identities that will be granted the privilege in `role`.
   Each entry can have one of the following values:
   * **userAccount:{user_id}**: A unique user ID that represents a specific Yandex account.
+  * **serviceAccount:{service_account_id}**: A unique service account ID.
   * **system:{allUsers|allAuthenticatedUsers}**: see [system groups](https://cloud.yandex.com/docs/iam/concepts/access-control/system-group)


### PR DESCRIPTION
I found that resource `function_iam_binding` can use  `serviceAccount:` as a member, but that is not documented.