### PR TITLE
Add serverless access config option to PostgreSQL MDB

### DIFF
--- a/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
+++ b/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
@@ -88,6 +88,7 @@ The `access` block supports:
 
 * `data_lens` - Allow access for [Yandex DataLens](https://cloud.yandex.com/services/datalens).
 * `web_sql` - Allows access for [SQL queries in the management console](https://cloud.yandex.com/docs/managed-postgresql/operations/web-sql-query)
+* `serverless` - Allow access for [Serverless connection](https://cloud.yandex.ru/docs/functions/operations/database-connection#connect). 
 
 
 The `performance_diagnostics` block supports:

--- a/website/docs/r/mdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/mdb_postgresql_cluster.html.markdown
@@ -502,9 +502,11 @@ The `backup_window_start` block supports:
 
 The `access` block supports:
 
-* `data_lens` - (Optional) Allow access for [Yandex DataLens](https://cloud.yandex.com/services/datalens).
+* `data_lens` - (Optional) Allow access for [Yandex DataLens](https://cloud.yandex.com/services/datalens). Can be either `true` or `false`.
 
-* `web_sql` - Allows access for [SQL queries in the management console](https://cloud.yandex.com/docs/managed-postgresql/operations/web-sql-query)
+* `web_sql` - (Optional) Allows access for [SQL queries in the management console](https://cloud.yandex.com/docs/managed-postgresql/operations/web-sql-query). Can be either `true` or `false`.
+
+* `serverless` - (Optional) Allow access for [Serverless connection](https://cloud.yandex.ru/docs/functions/operations/database-connection#connect). Can be either `true` or `false`.
 
 The `performance_diagnostics` block supports:
 

--- a/yandex/data_source_yandex_mdb_postgresql_cluster.go
+++ b/yandex/data_source_yandex_mdb_postgresql_cluster.go
@@ -38,6 +38,10 @@ func dataSourceYandexMDBPostgreSQLCluster() *schema.Resource {
 										Type:     schema.TypeBool,
 										Computed: true,
 									},
+									"serverless": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
 								},
 							},
 						},

--- a/yandex/mdb_postgresql_structures.go
+++ b/yandex/mdb_postgresql_structures.go
@@ -209,6 +209,7 @@ func flattenPGAccess(a *postgresql.Access) ([]interface{}, error) {
 
 	out["data_lens"] = a.DataLens
 	out["web_sql"] = a.WebSql
+	out["serverless"] = a.Serverless
 
 	return []interface{}{out}, nil
 }
@@ -1185,6 +1186,10 @@ func expandPGAccess(d *schema.ResourceData) *postgresql.Access {
 
 	if v, ok := d.GetOk("config.0.access.0.web_sql"); ok {
 		out.WebSql = v.(bool)
+	}
+
+	if v, ok := d.GetOk("config.0.access.0.serverless"); ok {
+		out.Serverless = v.(bool)
 	}
 
 	return out

--- a/yandex/resource_yandex_mdb_postgresql_cluster.go
+++ b/yandex/resource_yandex_mdb_postgresql_cluster.go
@@ -174,6 +174,11 @@ func resourceYandexMDBPostgreSQLCluster() *schema.Resource {
 										Optional: true,
 										Computed: true,
 									},
+									"serverless": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
 								},
 							},
 						},


### PR DESCRIPTION
[API ref](https://cloud.yandex.ru/docs/managed-postgresql/api-ref/Cluster/) of postgresql MDB shows serverless exists.