### PR TITLE
Fix yandex_mdb_mongodb_cluster.user.permission.roles argument name in docs

### DIFF
--- a/website/docs/r/mdb_mongodb_cluster.html.markdown
+++ b/website/docs/r/mdb_mongodb_cluster.html.markdown
@@ -142,7 +142,7 @@ The `permission` block supports:
 
 * `database_name` - (Required) The name of the database that the permission grants access to.
 
-* `role` - (Optional) The role of the user in this database. For more information see [the official documentation](https://cloud.yandex.com/docs/managed-mongodb/concepts/users-and-roles).
+* `roles` - (Optional) The roles of the user in this database. For more information see [the official documentation](https://cloud.yandex.com/docs/managed-mongodb/concepts/users-and-roles).
 
 The `database` block supports:
 


### PR DESCRIPTION
Documentation contains wrong argument name for `yandex_mdb_mongodb_cluster.user.permission.roles`. Now it named as `role` but Terraform throws error:

```
│ Error: Unsupported argument
│ 
│   on mongodb.tf line 42, in resource "yandex_mdb_mongodb_cluster" "mongodb-cluster":
│   42:       role          = "readWrite"
│ 
│ An argument named "role" is not expected here. Did you mean "roles"?
```

https://github.com/yandex-cloud/terraform-provider-yandex/blob/89e73ad09c3cee4c9f1182d6ceb3ce6bda893e12/yandex/resource_yandex_mdb_mongodb_cluster.go#L55-L93