### PR TITLE
Add serverless attribute to access entity in yandex_mdb_postgresql_cluster resource and data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.72.0 (Unreleased)
 ENHANCEMENTS:
+* mdb: add `serverless` attribute to `access` entity in `yandex_mdb_postgresql_cluster` resource and data source
 * add `ssl_certificate` attribute in `yandex_cdn_resource` resource and data source
 * alb: change `http_backend` and `grpc_backend` and `stream_backend` and `healthcheck` attribute types from Set to List in `yandex_alb_backend_group` resource
 * mdb: add `priority` and `backup_priority` attributes to `host` entity in `yandex_mdb_mysql_cluster` resource and data source

--- a/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
+++ b/website/docs/d/datasource_mdb_postgresql_cluster.html.markdown
@@ -87,7 +87,8 @@ The `backup_window_start` block supports:
 The `access` block supports:
 
 * `data_lens` - Allow access for [Yandex DataLens](https://cloud.yandex.com/services/datalens).
-* `web_sql` - Allows access for [SQL queries in the management console](https://cloud.yandex.com/docs/managed-postgresql/operations/web-sql-query)
+* `web_sql` - Allow access for [SQL queries in the management console](https://cloud.yandex.com/docs/managed-postgresql/operations/web-sql-query)a
+* `serverless` - Allow access for [connection to managed databases from functions](https://cloud.yandex.com/docs/functions/operations/database-connection)
 
 
 The `performance_diagnostics` block supports:

--- a/website/docs/r/mdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/mdb_postgresql_cluster.html.markdown
@@ -504,7 +504,9 @@ The `access` block supports:
 
 * `data_lens` - (Optional) Allow access for [Yandex DataLens](https://cloud.yandex.com/services/datalens).
 
-* `web_sql` - Allows access for [SQL queries in the management console](https://cloud.yandex.com/docs/managed-postgresql/operations/web-sql-query)
+* `web_sql` - Allow access for [SQL queries in the management console](https://cloud.yandex.com/docs/managed-postgresql/operations/web-sql-query)
+
+* `serverless` - Allow access for [connection to managed databases from functions](https://cloud.yandex.com/docs/functions/operations/database-connection)
 
 The `performance_diagnostics` block supports:
 

--- a/yandex/data_source_yandex_mdb_postgresql_cluster.go
+++ b/yandex/data_source_yandex_mdb_postgresql_cluster.go
@@ -36,6 +36,11 @@ func dataSourceYandexMDBPostgreSQLCluster() *schema.Resource {
 										Type:     schema.TypeBool,
 										Computed: true,
 									},
+									"serverless": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+
 								},
 							},
 						},

--- a/yandex/mdb_postgresql_structures.go
+++ b/yandex/mdb_postgresql_structures.go
@@ -211,6 +211,7 @@ func flattenPGAccess(a *postgresql.Access) ([]interface{}, error) {
 
 	out["data_lens"] = a.DataLens
 	out["web_sql"] = a.WebSql
+	out["serverless"] = a.Serverless
 
 	return []interface{}{out}, nil
 }
@@ -1187,6 +1188,10 @@ func expandPGAccess(d *schema.ResourceData) *postgresql.Access {
 
 	if v, ok := d.GetOk("config.0.access.0.web_sql"); ok {
 		out.WebSql = v.(bool)
+	}
+
+	if v, ok := d.GetOk("config.0.access.0.serverless"); ok {
+		out.Serverless = v.(bool)
 	}
 
 	return out

--- a/yandex/resource_yandex_mdb_postgresql_cluster.go
+++ b/yandex/resource_yandex_mdb_postgresql_cluster.go
@@ -174,6 +174,11 @@ func resourceYandexMDBPostgreSQLCluster() *schema.Resource {
 										Optional: true,
 										Computed: true,
 									},
+									"serverless": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
 								},
 							},
 						},

--- a/yandex/resource_yandex_mdb_postgresql_cluster_test.go
+++ b/yandex/resource_yandex_mdb_postgresql_cluster_test.go
@@ -178,6 +178,8 @@ func TestAccMDBPostgreSQLCluster_full(t *testing.T) {
 					resource.TestCheckResourceAttr(pgResource, "folder_id", folderID),
 					resource.TestCheckResourceAttr(pgResource, "description", pgDesc2),
 					resource.TestCheckResourceAttrSet(pgResource, "host.0.fqdn"),
+					resource.TestCheckResourceAttrSet(pgResource, "config.0.access.0.web_sql"),
+					resource.TestCheckResourceAttrSet(pgResource, "config.0.access.0.serverless"),
 					testAccCheckMDBPGClusterContainsLabel(&cluster, "new_key", "new_value"),
 					testAccCheckMDBPGClusterHasResources(&cluster, "s2.micro", "network-ssd", 19327352832),
 					testAccCheckMDBPGClusterHasPoolerConfig(&cluster, "TRANSACTION", false),
@@ -901,7 +903,8 @@ resource "yandex_mdb_postgresql_cluster" "foo" {
       disk_type_id       = "network-ssd"
     }
     access {
-      web_sql = true
+      web_sql    = true
+	  serverless = true
     }
     performance_diagnostics {
       sessions_sampling_interval   = 9


### PR DESCRIPTION
Duplicate of #213 but with tests and a record in the changelog.
Tests passed.

```
➜  terraform-provider-yandex git:(mdb-postgres-serverless-access-support) ✗ go test ./yandex -run TestAccDataSourceMDBPostgreSQL -v  -timeout 120m
=== RUN   TestAccDataSourceMDBPostgreSQLCluster_byID
=== PAUSE TestAccDataSourceMDBPostgreSQLCluster_byID
=== RUN   TestAccDataSourceMDBPostgreSQLCluster_byName
=== PAUSE TestAccDataSourceMDBPostgreSQLCluster_byName
=== CONT  TestAccDataSourceMDBPostgreSQLCluster_byID
=== CONT  TestAccDataSourceMDBPostgreSQLCluster_byName
--- PASS: TestAccDataSourceMDBPostgreSQLCluster_byName (447.82s)
--- PASS: TestAccDataSourceMDBPostgreSQLCluster_byID (475.78s)
PASS
ok      github.com/yandex-cloud/terraform-provider-yandex/yandex        477.472s
➜  terraform-provider-yandex git:(mdb-postgres-serverless-access-support) ✗ go test ./yandex -run TestAccMDBPostgreSQLCluster -v  -timeout 120m
=== RUN   TestAccMDBPostgreSQLCluster_full
=== PAUSE TestAccMDBPostgreSQLCluster_full
=== CONT  TestAccMDBPostgreSQLCluster_full
--- PASS: TestAccMDBPostgreSQLCluster_full (2138.25s)
PASS
ok      github.com/yandex-cloud/terraform-provider-yandex/yandex        2139.944s
```