### PR TITLE
Add 'folders' attribute to Cloud data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ BUG FIXES:
 ## 0.65.0 (October 14, 2021)
 FEATURES:
 * mdb: support Schema Registry in `yandex_mdb_kafka_cluster`
+* resourcemanager: data source `yandex_resourcemanager_cloud` now provides `folders` attribute
 
 FEATURES:
 * **New Resource:** `yandex_kms_symmetric_key_iam_binding`

--- a/website/docs/d/datasource_resourcemanager_cloud.html.markdown
+++ b/website/docs/d/datasource_resourcemanager_cloud.html.markdown
@@ -39,3 +39,4 @@ The following attributes are returned:
 * `name` - Name of the cloud.
 * `description` - Description of the cloud.
 * `created_at` - Cloud creation timestamp.
+* `folders` - List of folders in the cloud


### PR DESCRIPTION
Duplicate reverted https://github.com/yandex-cloud/terraform-provider-yandex/pull/207
see issue https://github.com/yandex-cloud/terraform-provider-yandex/issues/239

Additional `yandex_resourcemanager_cloud` data source attribute
```tf
 folders = [
   {
     folder_id = "06nur34....."
     name      = "some_name"
   },
   {
     folder_id = "8a8i9ag....."
     name      = "some_name2"
   },
```