### PR TITLE
Change memory to 2GB in examples

### DIFF
--- a/website/docs/e/coi_with_compute_instance.html.markdown
+++ b/website/docs/e/coi_with_compute_instance.html.markdown
@@ -178,7 +178,7 @@ resource "yandex_compute_instance_group" "ig-with-coi" {
   instance_template {
     platform_id = "standard-v1"
     resources {
-      memory = 1
+      memory = 2
       cores  = 1
     }
     boot_disk {

--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -22,7 +22,7 @@ resource "yandex_compute_instance_group" "group1" {
   instance_template {
     platform_id = "standard-v1"
     resources {
-      memory = 1
+      memory = 2
       cores  = 2
     }
     boot_disk {


### PR DESCRIPTION
Fix error:
```
the specified memory size is not available with 2 cores and 100% core fraction on platform "standard-v1"; allowed memory size: 2GB, 4GB, 6GB, 8GB, 10GB, 12GB, 14GB, 16GB.
```