### PR TITLE
Relax restictions on DNS recordset maximum length

### DIFF
--- a/yandex/resource_yandex_dns_recordset.go
+++ b/yandex/resource_yandex_dns_recordset.go
@@ -64,7 +64,7 @@ func resourceYandexDnsRecordSet() *schema.Resource {
 				MaxItems: 100,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringLenBetween(1, 255),
+					ValidateFunc: validation.StringLenBetween(1, 1024),
 				},
 				Set:              schema.HashString,
 				DiffSuppressFunc: dataDiffSuppressFunc,


### PR DESCRIPTION
At the moment the maximum length of a single recordset data item is
limited to 255 symbols. As a result it's impossible to add some types of
DNS records, e.g. DKIM TXT records with longer text data.

There is no any restiction on recordset item data length when using
Yandex CLI tool.

So there are two ways to be able to add DKIM records using Terraform
provider:

1. somehow relax restrictions (I believe 1024 is enough);
2. or disable recordset data item length validation completely.