### PR TITLE
[ydb] increase YDB dedicated creation timeout

### DIFF
--- a/yandex/resource_yandex_ydb_database_dedicated.go
+++ b/yandex/resource_yandex_ydb_database_dedicated.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-const yandexYDBDedicatedDefaultTimeout = 10 * time.Minute
+const yandexYDBDedicatedDefaultTimeout = 30 * time.Minute
 
 func resourceYandexYDBDatabaseDedicated() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
I think it is a good idea to increase YDB creation timeout. In fact, when dedicated database is created, many heavy operations such as instance group creation and storage groups allocation are performed, so increasing timeout should help.