### PR TITLE
fix typo cluster_id/id

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -172,7 +172,7 @@ that will cause problems for cluster and related node group deletion.
 
 ## Attributes Reference
 
-* `cluster_id` - (Computed) ID of a new Kubernetes cluster.
+* `id` - (Computed) ID of a new Kubernetes cluster.
 * `status` - (Computed)Status of the Kubernetes cluster.
 * `health` - (Computed) Health of the Kubernetes cluster.
 * `created_at` - (Computed) The Kubernetes cluster creation timestamp.


### PR DESCRIPTION
 plan
╷
│ Error: Unsupported attribute
│
│   on outputs.tf line 2, in output "k8s_cluster_id":
│    2:   value = yandex_kubernetes_cluster.k8s.cluster_id
│
│ This object has no argument, nested block, or exported attribute named
│ "cluster_id".