### PR TITLE
Fix go fmt issues

### DIFF
--- a/yandex/internal/mutexkv/mutexkv.go
+++ b/yandex/internal/mutexkv/mutexkv.go
@@ -8,7 +8,6 @@ import (
 // MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
 // serialize changes across arbitrary collaborators that share knowledge of the
 // keys they must serialize on.
-//
 type MutexKV struct {
 	lock  sync.Mutex
 	store map[string]*sync.Mutex

--- a/yandex/resource_yandex_storage_bucket.go
+++ b/yandex/resource_yandex_storage_bucket.go
@@ -1904,9 +1904,9 @@ func waitCorsDeleted(s3Client *s3.S3, bucket string) error {
 }
 
 // Returns true if the error matches all these conditions:
-//  * err is of type awserr.Error
-//  * Error.Code() matches code
-//  * Error.Message() contains message
+//   - err is of type awserr.Error
+//   - Error.Code() matches code
+//   - Error.Message() contains message
 func isAWSErr(err error, code string, message string) bool {
 	if err, ok := err.(awserr.Error); ok {
 		return err.Code() == code && strings.Contains(err.Message(), message)

--- a/yandex/resource_yandex_storage_bucket_test.go
+++ b/yandex/resource_yandex_storage_bucket_test.go
@@ -1199,7 +1199,7 @@ func testAccCheckStorageBucketSSE(n string, config *s3.ServerSideEncryptionConfi
 	}
 }
 
-//// These need a bit of randomness as the name can only be used once globally
+// // These need a bit of randomness as the name can only be used once globally
 func testAccBucketName(randInt int) string {
 	return fmt.Sprintf("tf-test-bucket-%d", randInt)
 }
@@ -1293,21 +1293,21 @@ func (b testAccStorageBucketConfigBuilder) asAdmin() testAccStorageBucketConfigB
 render creates new bucket config. For visual representation, note the following
 example of how it might look after calling this method:
 
-resource "yandex_storage_bucket" "test" {
-	bucket = "tf-test-bucket-%d"
+	resource "yandex_storage_bucket" "test" {
+		bucket = "tf-test-bucket-%d"
 
-	access_key = yandex_iam_service_account_static_access_key.sa-key.access_key
-	secret_key = yandex_iam_service_account_static_access_key.sa-key.secret_key
+		access_key = yandex_iam_service_account_static_access_key.sa-key.access_key
+		secret_key = yandex_iam_service_account_static_access_key.sa-key.secret_key
 
-	default_storage_class = "STANDARD"
+		default_storage_class = "STANDARD"
 
-	anonymous_access_flags {
-		list = false
-		read = false
+		anonymous_access_flags {
+			list = false
+			read = false
+		}
+
+		{ bucket statements on each line }
 	}
-
-	{ bucket statements on each line }
-}
 
 { after bucket statements on each line }
 


### PR DESCRIPTION
The `make fmtcheck` fails with the following error:


#### 1. fmtcheck output
```sh
kbespalov@home-pc:~/workspaces/terraform-provider-yandex$ make fmtcheck
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./yandex/internal/mutexkv/mutexkv.go
./yandex/resource_yandex_storage_bucket_test.go
./yandex/resource_yandex_storage_bucket.go
You can use the command: `make fmt` to reformat code.
make: *** [GNUmakefile:42: fmtcheck] Error 1
kbespalov@home-pc:~/workspaces/terraform-provider-yand
```

#### 2. go fmt output

```sh
 gofmt -d -l .
yandex/internal/mutexkv/mutexkv.go
diff yandex/internal/mutexkv/mutexkv.go.orig yandex/internal/mutexkv/mutexkv.go
--- yandex/internal/mutexkv/mutexkv.go.orig
+++ yandex/internal/mutexkv/mutexkv.go
@@ -8,7 +8,6 @@
 // MutexKV is a simple key/value store for arbitrary mutexes. It can be used to
 // serialize changes across arbitrary collaborators that share knowledge of the
 // keys they must serialize on.
-//
 type MutexKV struct {
        lock  sync.Mutex
        store map[string]*sync.Mutex
yandex/resource_yandex_storage_bucket.go
diff yandex/resource_yandex_storage_bucket.go.orig yandex/resource_yandex_storage_bucket.go
--- yandex/resource_yandex_storage_bucket.go.orig
+++ yandex/resource_yandex_storage_bucket.go
@@ -1904,9 +1904,9 @@
 }
 
 // Returns true if the error matches all these conditions:
-//  * err is of type awserr.Error
-//  * Error.Code() matches code
-//  * Error.Message() contains message
+//   - err is of type awserr.Error
+//   - Error.Code() matches code
+//   - Error.Message() contains message
 func isAWSErr(err error, code string, message string) bool {
        if err, ok := err.(awserr.Error); ok {
                return err.Code() == code && strings.Contains(err.Message(), message)
yandex/resource_yandex_storage_bucket_test.go
diff yandex/resource_yandex_storage_bucket_test.go.orig yandex/resource_yandex_storage_bucket_test.go
--- yandex/resource_yandex_storage_bucket_test.go.orig
+++ yandex/resource_yandex_storage_bucket_test.go
@@ -1199,7 +1199,7 @@
        }
 }
```
