### PR TITLE
MDB-19695: Use ClickHouse 22.8 in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ BUG FIXES:
 ENHANCEMENTS:
 * provider: Upgrade go-sdk and go-genproto to the latest version. This is needed for ALB RBAC feature. 
 * add `message_max_bytes`, `replica_fetch_max_bytes`, `ssl_cipher_suites`, `offsets_retention_minutes` attributes in `yandex_mdb_kafka_cluster` resource and data source
+* clickhouse: use version 22.8 for tests
 
 FEATURES:
 * mdb: add `backup_retain_period_days` attribute to `config` entity in `yandex_mdb_mysql_cluster` resource and data source

--- a/yandex/resource_yandex_mdb_clickhouse_cluster_test.go
+++ b/yandex/resource_yandex_mdb_clickhouse_cluster_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/mdb/clickhouse/v1"
 )
 
-const chVersion = "22.3"
+const chVersion = "22.8"
 const chResource = "yandex_mdb_clickhouse_cluster.foo"
 const chResourceSharded = "yandex_mdb_clickhouse_cluster.bar"
 const chResourceCloudStorage = "yandex_mdb_clickhouse_cluster.cloud"
@@ -413,7 +413,7 @@ func TestAccMDBClickHouseCluster_sharded(t *testing.T) {
 	})
 }
 
-// Test that a sharded ClickHouse Cluster can be created, updated and destroyed
+// Test that a ClickHouse Cluster with cloud storage can be created
 func TestAccMDBClickHouseCluster_cloud_storage(t *testing.T) {
 	t.Parallel()
 
@@ -429,7 +429,7 @@ func TestAccMDBClickHouseCluster_cloud_storage(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMDBClickHouseClusterDestroy,
 		Steps: []resource.TestStep{
-			// Create sharded ClickHouse Cluster
+			// Create ClickHouse Cluster with cloud storage
 			{
 				Config: testAccMDBClickHouseClusterConfigCloudStorage(chName, chDesc, bucketName, rInt),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
Use ClickHouse 22.8 in tests
Cloud storage isn't allowed in versions less than 22.8 now.