### PR TITLE
increase operation timeouts in yandex_serverless_container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.83.0 (Unreleased)
+FEATURES:
+* serverless: increase operation timeouts in `yandex_serverless_container` resource
 
 ## 0.82.0 (November 11, 2022)
 BUG FIXES:

--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -43,8 +43,9 @@ resource "yandex_compute_instance" "default" {
 resource "yandex_vpc_network" "foo" {}
 
 resource "yandex_vpc_subnet" "foo" {
-  zone       = "ru-central1-a"
-  network_id = "${yandex_vpc_network.foo.id}"
+  zone           = "ru-central1-a"
+  network_id     = "${yandex_vpc_network.foo.id}"
+  v4_cidr_blocks = ["10.5.0.0/24"]
 }
 ```
 

--- a/website/docs/r/storage_bucket.html.markdown
+++ b/website/docs/r/storage_bucket.html.markdown
@@ -480,7 +480,7 @@ The following arguments are supported:
 
 * `website` - (Optional) A [website object](https://cloud.yandex.com/docs/storage/concepts/hosting) (documented below).
 
-* `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://cloud.yandex.com/docs/storage/cors/) (documented below).
+* `cors_rule` - (Optional) A rule of [Cross-Origin Resource Sharing](https://cloud.yandex.com/docs/storage/concepts/cors) (documented below).
 
 * `versioning` - (Optional) A state of [versioning](https://cloud.yandex.com/docs/storage/concepts/versioning) (documented below)
 

--- a/yandex/resource_yandex_serverless_container.go
+++ b/yandex/resource_yandex_serverless_container.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
-const yandexServerlessContainerDefaultTimeout = 5 * time.Minute
+const yandexServerlessContainerDefaultTimeout = 15 * time.Minute
 
 func resourceYandexServerlessContainer() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
I have a problem with the resource “yandex_serverless_container”. 
My container is big, about 5 Gb and it prepares a long time (9-10 minutes).
Look:
<img width="1208" alt="Screenshot 2022-11-30 at 21 49 08" src="https://user-images.githubusercontent.com/19423656/204883069-6f049f1b-664d-4f8c-bf2d-20e98dff8cfc.png">

I've found [same problem](https://github.com/yandex-cloud/terraform-provider-yandex/pull/271) with cloud functions 