### PR TITLE
Fix typo at alb_http_router.html.markdown

### DIFF
--- a/website/docs/r/alb_http_router.html.markdown
+++ b/website/docs/r/alb_http_router.html.markdown
@@ -18,7 +18,7 @@ resource "yandex_alb_http_router" "tf-router" {
   name      = "my-http-router"
   labels = {
     tf-label    = "tf-label-value"
-    empty-label = ""s
+    empty-label = ""
   }
 }
 ```


### PR DESCRIPTION
`s` looks odd there