### PR TITLE
Fix docs for cm_certificate

### DIFF
--- a/website/docs/r/cm_certificate.html.markdown
+++ b/website/docs/r/cm_certificate.html.markdown
@@ -75,7 +75,6 @@ resource "yandex_dns_recordset" "example" {
 ```hcl
 resource "yandex_cm_certificate" "example" {
   name    = "example"
-  domains = ["example.com"]
 
   self_managed {
     certificate = "-----BEGIN CERTIFICATE----- ... -----END CERTIFICATE----- \n -----BEGIN CERTIFICATE----- ... -----END CERTIFICATE-----"
@@ -92,7 +91,7 @@ The following arguments are supported:
 * `folder_id` - (Optional) Folder that the resource belongs to. If value is omitted, the default provider folder is used.
 * `description` - (Optional) Certificate description.
 * `labels` - (Optional) Labels to assign to this certificate.
-* `domains` - (Optional) Domains for this certificate. Should be specified for managed certificates.
+* `domains` - (Optional) Domains for this certificate. Should be specified only for managed certificates.
 * `managed` - (Optional) Managed specification. Structure is documented below.
 * `self_managed` - (Optional) Self-managed specification. Structure is documented below.
 


### PR DESCRIPTION
Fix domains field in self_managed example doc

│ Error: Conflicting configuration arguments
│ 
│   with module.k8s.yandex_cm_certificate.alb,
│   on modules/tf-yc-k8s-cluster/load_balancer.tf line 53, in resource "yandex_cm_certificate" "alb":
│   53: resource "yandex_cm_certificate" "alb" {
│ 
│ "self_managed": conflicts with domains