### PR TITLE
Fix: kubernetes: observe and update field master.regional.location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ BUG FIXES:
 * compute: fix `filesystem` in `compute_instance_group` resource
 * greenplum: add Cloud Storage support
 * postgresql: do not recreate cluster on network change
+* kubernetes: fix bug with observe and update of field `master.regional.location` in `yandex_kubernetes_cluster` resource
 
 WARNING:
 * managed-kafka: 'unmanaged_topics' cluster flag are now deprecated


### PR DESCRIPTION
When importing a `yandex_kubernetes_cluster` resource, there are no fields about the master subnet configuration. Therefore, if you change the resource manually, drift will occur.
```bash
terraform import yandex_kubernetes_cluster.cluster_resource_name <cluster_id>
```
<img width="1347" alt="image" src="https://github.com/yandex-cloud/terraform-provider-yandex/assets/50084893/373fddd0-4d5e-4c84-9776-d75881bd9746">

> On the left is the output of the provider containing the error. On the right - with correction
