### PR TITLE
Fix: typo in alb documentation, wrong value for http_code_interval

### DIFF
--- a/website/docs/r/alb_load_balancer.html.markdown
+++ b/website/docs/r/alb_load_balancer.html.markdown
@@ -46,7 +46,7 @@ resource "yandex_alb_load_balancer" "test-balancer" {
   
   log_options {
     discard_rule {
-      http_code_intervals = ["2XX"]
+      http_code_intervals = ["HTTP_2XX"]
       discard_percent = 75
     }
   }


### PR DESCRIPTION
```
http_code_interval = 2XX -> HTTP_2XX
```