### PR TITLE
Fix: changing order yandex_compute_snapshot_schedule.disk_ids

### DIFF
--- a/yandex/data_source_yandex_compute_snapshot_schedule.go
+++ b/yandex/data_source_yandex_compute_snapshot_schedule.go
@@ -117,12 +117,13 @@ func dataSourceYandexComputeSnapshotSchedule() *schema.Resource {
 			},
 
 			"disk_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Optional: true,
+				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				Optional: true,
+				Computed: true,
+				Set:      schema.HashString,
 			},
 		},
 	}

--- a/yandex/resource_yandex_compute_snapshot_schedule.go
+++ b/yandex/resource_yandex_compute_snapshot_schedule.go
@@ -47,12 +47,13 @@ func resourceYandexComputeSnapshotSchedule() *schema.Resource {
 			},
 
 			"disk_ids": {
-				Type: schema.TypeList,
+				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 				Optional: true,
 				Computed: true,
+				Set:      schema.HashString,
 			},
 
 			"folder_id": {
@@ -163,7 +164,7 @@ func resourceYandexComputeSnapshotScheduleCreate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 
-	diskIds := expandStringSlice(d.Get("disk_ids").([]interface{}))
+	diskIds := convertStringSet(d.Get("disk_ids").(*schema.Set))
 
 	req := &compute.CreateSnapshotScheduleRequest{
 		FolderId:       folderID,
@@ -416,7 +417,7 @@ func updateSnapshotScheduleDisks(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	newDisks := make(map[string]bool)
-	for _, d := range expandStringSlice(d.Get("disk_ids").([]interface{})) {
+	for _, d := range convertStringSet(d.Get("disk_ids").(*schema.Set)) {
 		newDisks[d] = true
 	}
 


### PR DESCRIPTION
Issue: https://github.com/yandex-cloud/terraform-provider-yandex/issues/329

In case of  the `yandex_compute_snapshot_schedule` resource ordering of the `disk_ids` is not significant. We can use `TypeSet` instead of `TypeList` to  get rid of the terraform state drift.

Create `yandex_compute_snapshot_schedule` resource:
```
$ terraform apply -auto-approve

Terraform will perform the following actions:

  # yandex_compute_snapshot_schedule.test_snapshot will be created
  + resource "yandex_compute_snapshot_schedule" "test_snapshot" {
      + created_at     = (known after apply)
      + disk_ids       = [
          + "fhmbitq6feqcit01cme9",
          + "fhms00ovair2co66fgp3",
          + "fhmgjnqbasu47ol25dbh",
          + "fhmtacjc9op19guj9lp4",
        ]
      + folder_id      = (known after apply)
      + id             = (known after apply)
      + name           = "test-snapshots"
      + snapshot_count = 1
      + status         = (known after apply)

      + schedule_policy {
          + expression = "22 9 * * *"
          + start_at   = (known after apply)
        }

      + snapshot_spec {
          + description = "Scheduling snapshots for test virtual machines"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
yandex_compute_snapshot_schedule.test_snapshot: Creating...
yandex_compute_snapshot_schedule.test_snapshot: Creation complete after 5s [id=fd8rasjd02quou3mls6q]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Before(we always have drift - `TypeList`):
```
$ terraform plan

yandex_compute_snapshot_schedule.test_snapshot: Refreshing state... [id=fd8rasjd02quou3mls6q]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # yandex_compute_snapshot_schedule.test_snapshot will be updated in-place
  ~ resource "yandex_compute_snapshot_schedule" "test_snapshot" {
      ~ disk_ids       = [
          - "fhmtacjc9op19guj9lp4",
          - "fhmgjnqbasu47ol25dbh",
          - "fhms00ovair2co66fgp3",
            "fhmbitq6feqcit01cme9",
          + "fhms00ovair2co66fgp3",
          + "fhmgjnqbasu47ol25dbh",
          + "fhmtacjc9op19guj9lp4",
        ]
        id             = "fd8rasjd02quou3mls6q"
        name           = "test-snapshots"
        # (5 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

After(`TypeSet`):
```
$ terraform plan

yandex_compute_snapshot_schedule.test_snapshot: Refreshing state... [id=fd8rasjd02quou3mls6q]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```