### PR TITLE
Fix for OpenSearch dashboardsList length check

### DIFF
--- a/website/docs/r/mdb_opensearch_cluster.html.markdown
+++ b/website/docs/r/mdb_opensearch_cluster.html.markdown
@@ -242,7 +242,7 @@ The `resources` block supports:
 
 * `resources_preset_id` - (Required) The ID of the preset for computational resources available to a host (CPU, memory etc.). For more information, see [the official documentation](https://cloud.yandex.com/docs/managed-opensearch/concepts).
 
-* `disk_size` - (Required) Volume of the storage available to a host, in gigabytes.
+* `disk_size` - (Required) Volume of the storage available to a host, in bytes.
 
 * `disk_type_id` - (Required) Type of the storage of OpenSearch hosts.
 

--- a/yandex/mdb_opensearch_structures.go
+++ b/yandex/mdb_opensearch_structures.go
@@ -103,7 +103,7 @@ func expandOpenSearchConfigCreateSpec(raw interface{}) *opensearch.ConfigCreateS
 	}
 
 	dashboardsList := d["dashboards"].([]interface{})
-	if len(openSearchList) != 0 {
+	if len(dashboardsList) != 0 {
 		dashboards := dashboardsList[0].(map[string]interface{})
 
 		config.DashboardsSpec = &opensearch.DashboardsCreateSpec{


### PR DESCRIPTION
Using OpenSearch configuration without dashboard config section lead Terraform to a runtime error. See [Issue-403](https://github.com/yandex-cloud/terraform-provider-yandex/issues/403).

In addition, it fix typo in OpenSearch documentation for disk_size. This argument accept size in bytes instead of gigabytes.
Using value in gigabyte lead to the following error:

```
yandex_mdb_opensearch_cluster.foo: Creating...
╷
│ Error: Error while requesting API to create OpenSearch Cluster: server-request-id = b735c9d2-0ab0-4bf9-9abe-c7719a73ef2c server-trace-id = 5315c679db36e0ef:1261d5ba74e2bed:5315c679db36e0ef:1 client-request-id = 4d2d6a3e-dc07-4f14-92ec-7aa2695630fd client-trace-id = 2a17c7cf-7f3c-4bda-b034-d995ec293ab2 rpc error: code = InvalidArgument desc = invalid disk size, must be inside [10737418240,4398046511105) range
```