### PR TITLE
Update compute_instance.html.markdown

### DIFF
--- a/website/docs/r/compute_instance.html.markdown
+++ b/website/docs/r/compute_instance.html.markdown
@@ -127,7 +127,7 @@ The `boot_disk` block supports:
 
 * `mode` - (Optional) Type of access to the disk resource. By default, a disk is attached in `READ_WRITE` mode.
 
-* `disk_id` - (Optional) The ID of the existing disk (such as those managed by
+* `disk_id` - (Required) The ID of the existing disk (such as those managed by
     `yandex_compute_disk`) to attach as a boot disk.
 
 * `initialize_params` - (Optional) Parameters for a new disk that will be created


### PR DESCRIPTION
Fixed because `rpc error: code = InvalidArgument desc = Request validation error: BootDiskSpec: Disk: missing required field`

With empty `boot_disk` block I face to :

```
╷
│ Error: Error while requesting API to create instance: server-request-id = [__] server-trace-id = [__]:1 client-request-id = [__] client-trace-id = [__] rpc error: code = InvalidArgument desc = Request validation error: BootDiskSpec: Disk: missing required field
│ 
│   with yandex_compute_instance.[__],
│   on [__].tf line 48, in resource "yandex_compute_instance" "[__]":
│   48: resource "yandex_compute_instance" "[__]" {

```