### PR TITLE
implement auto_scale_type support for compute_instance_group resource/datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+FEATURES:
+* compute: support `auto_scale_type` in `scale_policy.auto_scale` in `compute_instance_group` resource and datasource
+
 ## 0.126.0 (July 30, 2024)
 
 FEATURES:

--- a/website/docs/d/datasource_compute_instance_group.html.markdown
+++ b/website/docs/d/datasource_compute_instance_group.html.markdown
@@ -97,6 +97,8 @@ The `fixed_scale` block supports:
 
 The `auto_scale` block supports:
 
+* `auto_scale_type` - Autoscale type, `ZONAL` or `REGIONAL`.
+
 * `initial_size` - The initial number of instances in the instance group.
 
 * `measurement_duration` - The amount of time, in seconds, that metrics are averaged for.
@@ -121,6 +123,8 @@ will not decrease even if the average load falls below the value of `cpu_utiliza
 ---
 
 The `test_auto_scale` block supports:
+
+* `auto_scale_type` - Autoscale type `ZONAL` or `REGIONAL`.
 
 * `initial_size` - The initial number of instances in the instance group.
 

--- a/website/docs/r/compute_instance_group.html.markdown
+++ b/website/docs/r/compute_instance_group.html.markdown
@@ -427,6 +427,8 @@ the instance group will increase the number of virtual machines in the group.
 
 * `cpu_utilization_target` - (Required) Target CPU load level.
 
+* `auto_scale_type` - (Optional). Autoscale type, can be `ZONAL` or `REGIONAL`. By default `ZONAL` type is used.
+
 * `min_zone_size` - (Optional) The minimum number of virtual machines in a single availability zone.
 
 * `max_size` - (Optional) The maximum number of virtual machines in the group.
@@ -451,6 +453,8 @@ If the average value at the end of the interval is higher than the `cpu_utilizat
 the instance group will increase the number of virtual machines in the group.
 
 * `cpu_utilization_target` - (Required) Target CPU load level.
+
+* `auto_scale_type` - (Optional). Autoscale type, can be `ZONAL` or `REGIONAL`. By default `ZONAL` type is used.
 
 * `min_zone_size` - (Optional) The minimum number of virtual machines in a single availability zone.
 

--- a/yandex/data_source_yandex_compute_instance_group.go
+++ b/yandex/data_source_yandex_compute_instance_group.go
@@ -484,6 +484,10 @@ func dataSourceYandexComputeInstanceGroup() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"auto_scale_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									"min_zone_size": {
 										Type:     schema.TypeInt,
 										Computed: true,
@@ -557,6 +561,10 @@ func dataSourceYandexComputeInstanceGroup() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"auto_scale_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									"min_zone_size": {
 										Type:     schema.TypeInt,
 										Computed: true,

--- a/yandex/data_source_yandex_compute_instance_group_test.go
+++ b/yandex/data_source_yandex_compute_instance_group_test.go
@@ -164,6 +164,7 @@ func testAccDataSourceComputeInstanceGroupCheck(datasourceName string, resourceN
 
 func testAccDataSourceComputeInstanceGroupAutoScaleCheck(datasourceName string, resourceName string) resource.TestCheckFunc {
 	instanceAttrsToTest := []string{
+		"scale_policy.0.auto_scale.0.auto_scale_type",
 		"scale_policy.0.auto_scale.0.initial_size",
 		"scale_policy.0.auto_scale.0.max_size",
 		"scale_policy.0.auto_scale.0.min_zone_size",

--- a/yandex/ig_structures.go
+++ b/yandex/ig_structures.go
@@ -272,6 +272,7 @@ func flattenInstanceGroupAutoScale(sp *instancegroup.ScalePolicy_AutoScale) ([]m
 	subres["min_zone_size"] = int(sp.MinZoneSize)
 	subres["max_size"] = int(sp.MaxSize)
 	subres["initial_size"] = int(sp.InitialSize)
+	subres["auto_scale_type"] = instancegroup.ScalePolicy_AutoScale_AutoScaleType_name[int32(sp.AutoScaleType)]
 
 	if sp.MeasurementDuration != nil {
 		subres["measurement_duration"] = int(sp.MeasurementDuration.Seconds)
@@ -861,6 +862,14 @@ func expandInstanceGroupAutoScale(d *schema.ResourceData, prefix string) (*insta
 		MinZoneSize: int64(d.Get(prefix + ".min_zone_size").(int)),
 		MaxSize:     int64(d.Get(prefix + ".max_size").(int)),
 		InitialSize: int64(d.Get(prefix + ".initial_size").(int)),
+	}
+
+	if v, ok := d.GetOk(prefix + ".auto_scale_type"); ok {
+		autoScaleType, ok := instancegroup.ScalePolicy_AutoScale_AutoScaleType_value[strings.ToUpper(v.(string))]
+		if !ok {
+			return nil, fmt.Errorf("failed to resolve AutoScaleType: found %s", v)
+		}
+		autoScale.AutoScaleType = instancegroup.ScalePolicy_AutoScale_AutoScaleType(autoScaleType)
 	}
 
 	if v, ok := d.GetOk(prefix + ".measurement_duration"); ok {

--- a/yandex/ig_structures_test.go
+++ b/yandex/ig_structures_test.go
@@ -622,6 +622,7 @@ func TestFlattenInstanceGroupScalePolicy(t *testing.T) {
 			spec: &instancegroup.ScalePolicy{
 				ScaleType: &instancegroup.ScalePolicy_AutoScale_{
 					AutoScale: &instancegroup.ScalePolicy_AutoScale{
+						AutoScaleType:       instancegroup.ScalePolicy_AutoScale_REGIONAL,
 						MinZoneSize:         1,
 						MaxSize:             2,
 						MeasurementDuration: &duration.Duration{Seconds: 10},
@@ -633,6 +634,7 @@ func TestFlattenInstanceGroupScalePolicy(t *testing.T) {
 				{
 					"auto_scale": []map[string]interface{}{
 						{
+							"auto_scale_type":      "REGIONAL",
 							"min_zone_size":        1,
 							"max_size":             2,
 							"initial_size":         3,
@@ -647,6 +649,7 @@ func TestFlattenInstanceGroupScalePolicy(t *testing.T) {
 			spec: &instancegroup.ScalePolicy{
 				ScaleType: &instancegroup.ScalePolicy_AutoScale_{
 					AutoScale: &instancegroup.ScalePolicy_AutoScale{
+						AutoScaleType:         instancegroup.ScalePolicy_AutoScale_ZONAL,
 						MinZoneSize:           1,
 						MaxSize:               2,
 						MeasurementDuration:   &duration.Duration{Seconds: 10},
@@ -661,6 +664,7 @@ func TestFlattenInstanceGroupScalePolicy(t *testing.T) {
 				{
 					"auto_scale": []map[string]interface{}{
 						{
+							"auto_scale_type":        "ZONAL",
 							"min_zone_size":          1,
 							"max_size":               2,
 							"initial_size":           3,
@@ -678,6 +682,7 @@ func TestFlattenInstanceGroupScalePolicy(t *testing.T) {
 			spec: &instancegroup.ScalePolicy{
 				ScaleType: &instancegroup.ScalePolicy_AutoScale_{
 					AutoScale: &instancegroup.ScalePolicy_AutoScale{
+						AutoScaleType:         instancegroup.ScalePolicy_AutoScale_ZONAL,
 						MinZoneSize:           1,
 						MaxSize:               2,
 						MeasurementDuration:   &duration.Duration{Seconds: 10},
@@ -707,6 +712,7 @@ func TestFlattenInstanceGroupScalePolicy(t *testing.T) {
 				{
 					"auto_scale": []map[string]interface{}{
 						{
+							"auto_scale_type":        "ZONAL",
 							"min_zone_size":          1,
 							"max_size":               2,
 							"initial_size":           3,

--- a/yandex/resource_yandex_compute_instance_group.go
+++ b/yandex/resource_yandex_compute_instance_group.go
@@ -544,6 +544,12 @@ func resourceYandexComputeInstanceGroup() *schema.Resource {
 							ConflictsWith: []string{"scale_policy.0.fixed_scale"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"auto_scale_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      "ZONAL",
+										ValidateFunc: validation.StringInSlice([]string{"REGIONAL", "ZONAL"}, false),
+									},
 									"initial_size": {
 										Type:     schema.TypeInt,
 										Required: true,
@@ -624,6 +630,12 @@ func resourceYandexComputeInstanceGroup() *schema.Resource {
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"auto_scale_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:      "ZONAL",
+										ValidateFunc: validation.StringInSlice([]string{"REGIONAL", "ZONAL"}, false),
+									},
 									"initial_size": {
 										Type:     schema.TypeInt,
 										Required: true,

--- a/yandex/resource_yandex_compute_instance_group_test.go
+++ b/yandex/resource_yandex_compute_instance_group_test.go
@@ -1404,6 +1404,7 @@ resource "yandex_compute_instance_group" "group1" {
 
   scale_policy {
     auto_scale {
+      auto_scale_type = "REGIONAL"
       initial_size           = 1
       max_size               = 2
       min_zone_size          = 1
@@ -1505,6 +1506,7 @@ resource "yandex_compute_instance_group" "group1" {
       size = 2
     }
     test_auto_scale {
+      auto_scale_type = "REGIONAL"
       initial_size           = 1
       max_size               = 2
       min_zone_size          = 1
@@ -2719,6 +2721,9 @@ func testAccCheckComputeInstanceGroupAutoScalePolicy(ig *instancegroup.InstanceG
 		}
 
 		sp := ig.ScalePolicy.GetAutoScale()
+		if sp.AutoScaleType != instancegroup.ScalePolicy_AutoScale_REGIONAL {
+			return fmt.Errorf("wrong auto_scale_type on instance group %s", ig.Name)
+		}
 		if sp.InitialSize != 1 {
 			return fmt.Errorf("wrong initialsize on instance group %s", ig.Name)
 		}
@@ -2742,6 +2747,9 @@ func testAccCheckComputeInstanceGroupTestAutoScalePolicy(ig *instancegroup.Insta
 		}
 
 		sp := ig.ScalePolicy.GetTestAutoScale()
+		if sp.AutoScaleType != instancegroup.ScalePolicy_AutoScale_REGIONAL {
+			return fmt.Errorf("wrong auto_scale_type on instance group %s", ig.Name)
+		}
 		if sp.InitialSize != 1 {
 			return fmt.Errorf("wrong initial size on instance group %s", ig.Name)
 		}


### PR DESCRIPTION
compute: support `auto_scale_type` in `scale_policy.auto_scale` in `compute_instance_group` resource and datasource

fixes: 
- https://github.com/yandex-cloud/terraform-provider-yandex/issues/214

doc: https://cloud.yandex.ru/ru/docs/compute/concepts/instance-groups/policies/scale-policy#auto-scale-policy