### PR TITLE
Fix: update data_yandex_mdb_kafka_user documentation

### DIFF
--- a/website/docs/d/datasource_mdb_kafka_user.html.markdown
+++ b/website/docs/d/datasource_mdb_kafka_user.html.markdown
@@ -17,7 +17,6 @@ Get information about a user of the Yandex Managed Kafka cluster. For more infor
 data "yandex_mdb_kafka_user" "foo" {
   cluster_id = "some_cluster_id"
   name = "test"
-  password = "pass123"
 }
 
 output "username" {
@@ -31,17 +30,16 @@ The following arguments are supported:
 
 * `cluster_id` - (Required) The ID of the Kafka cluster.
 * `name` - (Required) The name of the Kafka user.
-* `password` - (Required) The password of the user.
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `permission` - (Optional) Set of permissions granted to the user. The structure is documented below.
+* `permission` - Set of permissions granted to the user. The structure is documented below.
 
 The `permission` block supports:
 
-* `topic_name` - (Required) The name of the topic that the permission grants access to.
-* `role` - (Required) The role type to grant to the topic.
-* `allow_hosts` - (Optional) Set of hosts, to which this permission grants access to.
+* `topic_name` - The name of the topic that the permission grants access to.
+* `role` - The role type to grant to the topic.
+* `allow_hosts` - Set of hosts, to which this permission grants access to.


### PR DESCRIPTION
The data resource doesn't support the password argument, only cluster_id and name arguments could be passed (https://github.com/yandex-cloud/terraform-provider-yandex/blob/master/yandex/data_source_yandex_mdb_kafka_user.go). If we set the password  we will get an error like:

```
 Error: Value for unconfigurable attribute
│ 
│   with data.yandex_mdb_kafka_user.this,
│   on main.tf line 68, in data "yandex_mdb_kafka_user" "this":
│   68:   password = "abc"
│ 
│ Can't configure a value for "password": its value will be decided automatically based on the result of applying this configuration.
```
