### PR TITLE
Added provision_policy to serverless containers

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240606-022132.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240606-022132.yaml
@@ -1,0 +1,3 @@
+kind: ENHANCEMENTS
+body: Added provision_policy to serverless containers
+time: 2024-06-06T02:21:32.908551Z

--- a/website/docs/r/serverless_container.html.markdown
+++ b/website/docs/r/serverless_container.html.markdown
@@ -34,6 +34,9 @@ resource "yandex_serverless_container" "test-container" {
     log_group_id = "e2392vo6d1bne2aeq9fr"
     min_level = "ERROR"
   }
+  provision_policy {
+    min_instances = 1
+  }
 }
 ```
 ```hcl
@@ -80,6 +83,9 @@ The following arguments are supported:
 * `image.0.environment` -  A set of key/value environment variable pairs for Yandex Cloud Serverless Container
 
 * `log_options` - Options for logging from Yandex Cloud Serverless Container
+
+* `provision_policy` - Provision policy. If specified the revision will have prepared instances 
+* `provision_policy.0.min_instances` - Minimum number of prepared instances that are always ready to serve requests
 
 ## Attributes Reference
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

I added missed property for serverless containers - provision_policy

```
  provision_policy {
    min_instances = 1
  }
```

This PR solves the issue: https://github.com/yandex-cloud/terraform-provider-yandex/issues/399