### PR TITLE
Fix panic error in Grpc Healthcheck

### DIFF
--- a/yandex/alb_structures.go
+++ b/yandex/alb_structures.go
@@ -1482,12 +1482,12 @@ func expandALBGRPCHealthCheck(v interface{}) *apploadbalancer.HealthCheck_GrpcHe
 	healthCheck := &apploadbalancer.HealthCheck_GrpcHealthCheck{}
 
 	if config, ok := v.(map[string]interface{}); ok {
-        if val, ok := config["service_name"]; ok {
-            if serviceName, ok := val.(string); ok {
-                healthCheck.SetServiceName(serviceName)
-            }
-        }
-    }
+		if val, ok := config["service_name"]; ok {
+			if serviceName, ok := val.(string); ok {
+				healthCheck.SetServiceName(serviceName)
+			}
+		}
+	}
 
 	return healthCheck
 }

--- a/yandex/alb_structures.go
+++ b/yandex/alb_structures.go
@@ -1480,11 +1480,14 @@ func expandALBHTTPHealthCheck(v interface{}) *apploadbalancer.HealthCheck_HttpHe
 
 func expandALBGRPCHealthCheck(v interface{}) *apploadbalancer.HealthCheck_GrpcHealthCheck {
 	healthCheck := &apploadbalancer.HealthCheck_GrpcHealthCheck{}
-	config := v.(map[string]interface{})
 
-	if val, ok := config["service_name"]; ok {
-		healthCheck.SetServiceName(val.(string))
-	}
+	if config, ok := v.(map[string]interface{}); ok {
+        if val, ok := config["service_name"]; ok {
+            if serviceName, ok := val.(string); ok {
+                healthCheck.SetServiceName(serviceName)
+            }
+        }
+    }
 
 	return healthCheck
 }


### PR DESCRIPTION
## Fix: Prevent panic when `grpc_healthcheck` is specified without `service_name`

### Issue Description
A panic occurs when attempting to pass `grpc_healthcheck {}` without specifying the `service_name`, even though the documentation states that `service_name` can be optional. The issue arises when `grpc_healthcheck` is provided without any fields or with `service_name` as an empty string or `null`.

### Example
Given the following configuration:
```hcl
healthcheck {
    timeout = "2s"
    interval = "1s"
    healthy_threshold = 2
    unhealthy_threshold = 5
    healthcheck_port = 17004
    grpc_healthcheck {}
}
```
The code results in a panic:
```
Stack trace from the terraform-provider-yandex_v0.117.0 plugin:

panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 129 [running]:
github.com/yandex-cloud/terraform-provider-yandex/yandex.expandALBGRPCHealthCheck(...)
        github.com/yandex-cloud/terraform-provider-yandex/yandex/alb_structures.go:1483
github.com/yandex-cloud/terraform-provider-yandex/yandex.expandHealthCheck(0xc0013eab70?, {0xc00066aca0, 0x1d})
        github.com/yandex-cloud/terraform-provider-yandex/yandex/alb_structures.go:1439 +0x7e5
github.com/yandex-cloud/terraform-provider-yandex/yandex.expandHealthChecks(0x1da4d80?, {0xc000793750?, 0x0?})
        github.com/yandex-cloud/terraform-provider-yandex/yandex/alb_structures.go:1402 +0xcf
github.com/yandex-cloud/terraform-provider-yandex/yandex.expandALBGRPCBackend(0xc0013eac78?, {0xc000793750, 0xf})
        github.com/yandex-cloud/terraform-provider-yandex/yandex/alb_structures.go:1585 +0x2c8
github.com/yandex-cloud/terraform-provider-yandex/yandex.expandALBGRPCBackends(0x55c0ac?)
        github.com/yandex-cloud/terraform-provider-yandex/yandex/alb_structures.go:1543 +0xac
github.com/yandex-cloud/terraform-provider-yandex/yandex.buildALBBackendGroupUpdateRequest(0xc0015aed80)
        github.com/yandex-cloud/terraform-provider-yandex/yandex/resource_yandex_alb_backend_group.go:592 +0x3a5
github.com/yandex-cloud/terraform-provider-yandex/yandex.resourceYandexALBBackendGroupUpdate(0xc0015aed80, {0x217ae80?, 0xc000c6af20})
        github.com/yandex-cloud/terraform-provider-yandex/yandex/resource_yandex_alb_backend_group.go:615 +0x185
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0x27d29a0?, {0x27d29a0?, 0xc001162d20?}, 0xd?, {0x217ae80?, 0xc000c6af20?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/resource.go:800 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000d1cd20, {0x27d29a0, 0xc001162d20}, 0xc0015cfd40, 0xc0015aec00, {0x217ae80, 0xc000c6af20})        
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/resource.go:919 +0x845
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000011080, {0x27d29a0?, 0xc001162870?}, 0xc00140ad20)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/grpc_provider.go:1078 +0xe8d
github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.ApplyResourceChange({{0x27ddd00?, 0xc000011080?}}, {0x27d29a0, 0xc001162870}, 0x0?)
        github.com/hashicorp/terraform-plugin-mux@v0.15.0/tf5to6server/tf5to6server.go:47 +0x5a
github.com/hashicorp/terraform-plugin-mux/tf6muxserver.(*muxServer).ApplyResourceChange(0x27d28f8?, {0x27d29a0?, 0xc00115bb90?}, 0xc00140acd0)
        github.com/hashicorp/terraform-plugin-mux@v0.15.0/tf6muxserver/mux_server_ApplyResourceChange.go:36 +0x1b5
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ApplyResourceChange(0xc000b00b40, {0x27d29a0?, 0xc00115a240?}, 0xc000240000)
        github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov6/tf6server/server.go:846 +0x3dc
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ApplyResourceChange_Handler({0x23c0940?, 0xc000b00b40}, {0x27d29a0, 0xc00115a240}, 0xc0015ae000, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.22.1/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:518 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00093c800, {0x27d29a0, 0xc00115a1b0}, {0x27dbd00, 0xc000fac820}, 0xc0015ac000, 0xc000fa2bd0, 0x413f618, 0x0)
        google.golang.org/grpc@v1.62.1/server.go:1386 +0xe69
google.golang.org/grpc.(*Server).handleStream(0xc00093c800, {0x27dbd00, 0xc000fac820}, 0xc0015ac000)
        google.golang.org/grpc@v1.62.1/server.go:1797 +0x1051
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.62.1/server.go:1027 +0x91
created by google.golang.org/grpc.(*Server).serveStreams.func2
        google.golang.org/grpc@v1.62.1/server.go:1038 +0x145

Error: The terraform-provider-yandex_v0.117.0 plugin crashed!
```
