### PR TITLE
Set value of labels in lower case

### DIFF
--- a/yandex/structures.go
+++ b/yandex/structures.go
@@ -19,18 +19,9 @@ import (
 	"google.golang.org/grpc"
 	proto "google.golang.org/protobuf/proto"
 
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/containerregistry/v1"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/dataproc/v1"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/iam/v1"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/k8s/v1"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1"
 	kmsasymmetricencryption "github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1/asymmetricencryption"
 	kmsasymmetricsignature "github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1/asymmetricsignature"
 	ltagent "github.com/yandex-cloud/go-genproto/yandex/cloud/loadtesting/api/v1/agent"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/organizationmanager/v1"
-	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
-
 	"github.com/yandex-cloud/terraform-provider-yandex/yandex/internal/hashcode"
 )
 
@@ -99,7 +90,7 @@ func expandLabels(v interface{}) (map[string]string, error) {
 		return m, nil
 	}
 	for k, val := range v.(map[string]interface{}) {
-		m[k] = val.(string)
+		m[k] = strings.ToLower(val.(string))
 	}
 	return m, nil
 }

--- a/yandex/structures.go
+++ b/yandex/structures.go
@@ -14,15 +14,22 @@ import (
 
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/compute/v1"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/containerregistry/v1"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/dataproc/v1"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/iam/v1"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/k8s/v1"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1"
+	kmsasymmetricencryption "github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1/asymmetricencryption"
+	kmsasymmetricsignature "github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1/asymmetricsignature"
+	ltagent "github.com/yandex-cloud/go-genproto/yandex/cloud/loadtesting/api/v1/agent"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/organizationmanager/v1"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
+	"github.com/yandex-cloud/terraform-provider-yandex/yandex/internal/hashcode"
 	"google.golang.org/genproto/googleapis/type/dayofweek"
 	"google.golang.org/genproto/googleapis/type/timeofday"
 	"google.golang.org/grpc"
 	proto "google.golang.org/protobuf/proto"
-
-	kmsasymmetricencryption "github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1/asymmetricencryption"
-	kmsasymmetricsignature "github.com/yandex-cloud/go-genproto/yandex/cloud/kms/v1/asymmetricsignature"
-	ltagent "github.com/yandex-cloud/go-genproto/yandex/cloud/loadtesting/api/v1/agent"
-	"github.com/yandex-cloud/terraform-provider-yandex/yandex/internal/hashcode"
 )
 
 func IterateKeys(d *schema.ResourceData, key string) []string {


### PR DESCRIPTION
Greetings, please consider this PR. I encountered an unexpected behavior - values of any labels are passed in the case in which they were written. However, on the API side there is validation (regex: `/[-_./@0-9a-z]*/`), which prohibits the use of upper case.

If I understand your codebase correctly, the fix for this is very simple.

I'm sure this PR will be useful for everyone who uses task id from their task trackers in labels, because the most popular ones (Jira/YouTrack/Yandex Tracker) use uppercase as a key.
