### PR TITLE
Fix: add storage_bucket argument to http_backend block of alb_backend_group in documentation

### DIFF
--- a/docs/resources/alb_backend_group.md
+++ b/docs/resources/alb_backend_group.md
@@ -94,9 +94,6 @@ The `http_backend` block supports:
 * `load_balancing_config` - (Optional) Load Balancing Config specification that will be used by this backend. Structure is documented below.
 * `healthcheck` - (Optional) Healthcheck specification that will be used by this backend. Structure is documented below.
 * `tls` - (Optional) Tls specification that will be used by this backend. Structure is documented below.
-* `storage_bucket` - (Required) Name of bucket which should be used as a backend.
-
-~> **NOTE:** Only one of `target_group_ids` or `storage_bucket` should be specified.
 
 The `stream_backend` block supports:
 

--- a/docs/resources/alb_backend_group.md
+++ b/docs/resources/alb_backend_group.md
@@ -94,6 +94,9 @@ The `http_backend` block supports:
 * `load_balancing_config` - (Optional) Load Balancing Config specification that will be used by this backend. Structure is documented below.
 * `healthcheck` - (Optional) Healthcheck specification that will be used by this backend. Structure is documented below.
 * `tls` - (Optional) Tls specification that will be used by this backend. Structure is documented below.
+* `storage_bucket` - (Required) Name of bucket which should be used as a backend.
+
+~> **NOTE:** Only one of `target_group_ids` or `storage_bucket` should be specified.
 
 The `stream_backend` block supports:
 

--- a/templates/alb/resources/alb_backend_group.md.tmpl
+++ b/templates/alb/resources/alb_backend_group.md.tmpl
@@ -63,6 +63,9 @@ The `http_backend` block supports:
 * `load_balancing_config` - (Optional) Load Balancing Config specification that will be used by this backend. Structure is documented below.
 * `healthcheck` - (Optional) Healthcheck specification that will be used by this backend. Structure is documented below.
 * `tls` - (Optional) Tls specification that will be used by this backend. Structure is documented below.
+* `storage_bucket` - (Required) Name of bucket which should be used as a backend.
+
+~> **NOTE:** Only one of `target_group_ids` or `storage_bucket` should be specified.
 
 The `stream_backend` block supports:
 


### PR DESCRIPTION
There is no information about connecting alb backend group to storage bucket, so this error shows up, when trying to create group without target_group_ids

```
│ Error: Error expanding http backends while creating Application Backend Group: Either target_group_ids or storage_bucket should be specified for http backend
```
While argument storage_bucket is totally valid
