### PR TITLE
fix: saml federation user deletion method changed

### DIFF
--- a/yandex/resource_yandex_organizationmanager_saml_federation_user_account.go
+++ b/yandex/resource_yandex_organizationmanager_saml_federation_user_account.go
@@ -126,18 +126,12 @@ func resourceYandexOrganizationManagerSamlFederationUserAccountDelete(context co
 	config := meta.(*Config)
 	federationID, nameID := d.Get("federation_id").(string), d.Get("name_id").(string)
 
-	federation, err := getSamlFederation(context, config, federationID)
-	if err != nil {
-		return diag.Errorf("error deleting saml user '%s': %s", nameID, err)
+	req := &saml.DeleteFederatedUserAccountsRequest{
+		FederationId: federationID,
+		SubjectIds:   []string{d.Id()},
 	}
 
-	organizationID := federation.OrganizationId
-	req := &organizationmanager.DeleteMembershipRequest{
-		OrganizationId: organizationID,
-		SubjectId:      d.Id(),
-	}
-
-	op, err := config.sdk.WrapOperation(config.sdk.OrganizationManager().User().DeleteMembership(context, req))
+	op, err := config.sdk.WrapOperation(config.sdk.OrganizationManagerSAML().Federation().DeleteUserAccounts(context, req))
 	if err != nil {
 		return diag.Errorf("error on delete saml user '%s' operation creation: %s", nameID, err)
 	}


### PR DESCRIPTION
used now `OrganizationManager().User().DeleteMembership()` requires other permissions

impact: resource `yandex_organizationmanager_saml_federation_user_account` cannot be deleted with role `organization-manager.federations.admin`

commit will fix that

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.