### PR TITLE
fix: Fix removePgUserOwnerPermissions

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250610-140741.yaml
+++ b/.changes/unreleased/BUG FIXES-20250610-140741.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: 'postgresql: fix bug leading to panic when user has permissions to non-existent database'
+time: 2025-06-10T14:07:41.8547292+03:00

--- a/yandex/resource_yandex_mdb_postgresql_user.go
+++ b/yandex/resource_yandex_mdb_postgresql_user.go
@@ -422,7 +422,7 @@ func removePgUserOwnerPermissions(meta interface{}, clusterID string, username s
 
 	newPerms := []*postgresql.Permission{}
 	for _, p := range userPermissions {
-		if dbMap[p.DatabaseName].Owner != username {
+		if db, ok := dbMap[p.DatabaseName]; ok && db.Owner != username {
 			newPerms = append(newPerms, p)
 		}
 	}


### PR DESCRIPTION
mdb postgres user may have permissions to a database that no longer exists. This leads to panic

stacktrace:
```

Stack trace from the terraform-provider-yandex_v0.142.0.exe plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x50 pc=0x2064397]

goroutine 64 [running]:
github.com/yandex-cloud/terraform-provider-yandex/yandex.removePgUserOwnerPermissions({0x2a8bdc0?, 0xc000b1e840?}, {0xc001213c60, 0x14}, {0xc000627610, 0xb}, {0xc002041220, 0x3, 0x1?})
        github.com/yandex-cloud/terraform-provider-yandex/yandex/resource_yandex_mdb_postgresql_user.go:425 +0x2d7
github.com/yandex-cloud/terraform-provider-yandex/yandex.resourceYandexMDBPostgreSQLUserRead(0xc001ee7380, {0x2a8bdc0, 0xc000b1e840})
        github.com/yandex-cloud/terraform-provider-yandex/yandex/resource_yandex_mdb_postgresql_user.go:256 +0x2ed
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x33bdda8?, {0x33bdda8?, 0xc0010fe630?}, 0xd?, {0x2a8bdc0?, 0xc000b1e840?})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:811 +0x15f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000cef5e0, {0x33bdda8, 0xc0010fe630}, 0xc0008f40d0, {0x2a8bdc0, 0xc000b1e840})
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:1117 +0x529
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc001314480, {0x33bdda8?, 0xc0010fe510?}, 0xc000d30c00)
        github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/grpc_provider.go:708 +0x6c5
github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.ReadResource({{0x33d8ed8?, 0xc001314480?}}, {0x33bdda8?, 0xc0010fe510?}, 0xc000d30b00?)
        github.com/hashicorp/terraform-plugin-mux@v0.15.0/tf5to6server/tf5to6server.go:215 +0x225
github.com/hashicorp/terraform-plugin-mux/tf6muxserver.(*muxServer).ReadResource(0xc0004b1730, {0x33bdda8?, 0xc0010fe240?}, 0xc000d30b00)
        github.com/hashicorp/terraform-plugin-mux@v0.15.0/tf6muxserver/mux_server_ReadResource.go:35 +0x193
github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server.(*server).ReadResource(0xc00057ed20, {0x33bdda8?, 0xc001dad9e0?}, 0xc001a22d20)
        github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/tf6server/server.go:784 +0x309
github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6._Provider_ReadResource_Handler({0x2cc1aa0, 0xc00057ed20}, {0x33bdda8, 0xc001dad9e0}, 0xc001ee7100, 0x0)
        github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov6/internal/tfplugin6/tfplugin6_grpc.pb.go:482 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000f98400, {0x33bdda8, 0xc001dad950}, {0x33cc440, 0xc000a2c1a0}, 0xc000dfa900, 0xc000b9b9e0, 0x54ff088, 0x0)
        google.golang.org/grpc@v1.67.1/server.go:1394 +0xe49
google.golang.org/grpc.(*Server).handleStream(0xc000f98400, {0x33cc440, 0xc000a2c1a0}, 0xc000dfa900)
        google.golang.org/grpc@v1.67.1/server.go:1805 +0xe8b
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.67.1/server.go:1029 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 42
        google.golang.org/grpc@v1.67.1/server.go:1040 +0x125

Error: The terraform-provider-yandex_v0.142.0.exe plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.

```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru