### PR TITLE
fix: typo in yandex_mdb_postgresql_cluster_v2 example

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20250823-231308.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20250823-231308.yaml
@@ -1,0 +1,3 @@
+kind: ENHANCEMENTS
+body: 'postgresql: fixed typo in `yandex_mdb_postgresql_cluster_v2` example and docs'
+time: 2025-08-23T23:13:08.427996+03:00

--- a/docs/resources/mdb_postgresql_cluster_v2.md
+++ b/docs/resources/mdb_postgresql_cluster_v2.md
@@ -36,7 +36,7 @@ resource "yandex_mdb_postgresql_cluster_v2" "my_v2_cluster" {
     }
   }
 
-  maintenance_window {
+  maintenance_window = {
     type = "WEEKLY"
     day  = "SAT"
     hour = 12

--- a/examples/mdb_postgresql_cluster_v2/r_mdb_postgresql_cluster_v2_1.tf
+++ b/examples/mdb_postgresql_cluster_v2/r_mdb_postgresql_cluster_v2_1.tf
@@ -22,7 +22,7 @@ resource "yandex_mdb_postgresql_cluster_v2" "my_v2_cluster" {
     }
   }
 
-  maintenance_window {
+  maintenance_window = {
     type = "WEEKLY"
     day  = "SAT"
     hour = 12


### PR DESCRIPTION
Fixed typo in maintenance_window example and docs

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru