### PR TITLE
fix: atLeastIfConfiguredValidator behavior for unknown state

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250823-225116.yaml
+++ b/.changes/unreleased/BUG FIXES-20250823-225116.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: 'postgresql: fixed problem with pooler_config configuration passed through a module variable'
+time: 2025-08-23T22:51:16.499003+03:00

--- a/yandex-framework/services/mdb_postgresql_cluster_v2/validators.go
+++ b/yandex-framework/services/mdb_postgresql_cluster_v2/validators.go
@@ -92,7 +92,7 @@ func NewAtLeastIfConfiguredValidator(expressions ...path.Expression) *atLeastIfC
 
 func (at *atLeastIfConfiguredValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
 
-	if req.ConfigValue.IsNull() {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 


### PR DESCRIPTION
A value passed through a module variable or dependent on other values is set to unkown in validator.ObjectRequest, so it needs to be passed in validator
Issue: https://github.com/yandex-cloud/terraform-provider-yandex/issues/558

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru