### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,28 +20,28 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Unshallow
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
       -
         name: Import GPG key
         id: import_gpg
-        uses: paultyng/ghaction-import-gpg@v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ""
+        uses: crazy-max/ghaction-import-gpg@v6.3.0
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ""
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6.4.0
         with:
-          version: '1.26'
-          args: release --rm-dist --timeout 45m
+          version: '2.12.2'
+          args: release --clean --timeout 45m
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:
@@ -14,7 +15,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X github.com/yandex-cloud/terraform-provider-yandex/version.ProviderVersion={{.Version}}'
+    - '-s -w -X {{.ModulePath}}/version.ProviderVersion={{.Version}}'
   goos:
     - freebsd
     - windows
@@ -30,9 +31,11 @@ builds:
       goarch: '386'
     - goos: windows
       goarch: arm64
+    - goos: windows
+      goarch: arm
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: [ "zip" ]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
@@ -53,4 +56,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Что сделано:

- Обновлены все Actions до актуальных версий
- Заменен deprecated paultyng/ghaction-import-gpg на crazy-max/ghaction-import-gpg
- Setup Go теперь использует реальную версию из go.mod
- Обновлен go releaser 
- Убрана сборка для windows arm (windows не поддерживает ARM 6) 