### PR TITLE
Fix invalid CIDR address in examples/container_registry_ip_permission

### DIFF
--- a/examples/container_registry_ip_permission/r_container_registry_ip_permission_1.tf
+++ b/examples/container_registry_ip_permission/r_container_registry_ip_permission_1.tf
@@ -13,5 +13,5 @@ resource "yandex_container_registry" "my_registry" {
 resource "yandex_container_registry_ip_permission" "my_ip_permission" {
   registry_id = yandex_container_registry.my_registry.id
   push        = ["10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16"]
-  pull        = ["10.1.0.0/16", "10.5.0/16"]
+  pull        = ["10.1.0.0/16", "10.5.0.0/16"]
 }


### PR DESCRIPTION
Without fix this error occures:
<img width="832" height="150" alt="image" src="https://github.com/user-attachments/assets/3a8312d1-b632-4707-bae6-7ce4d9e0bd2e" />
