### PR TITLE
fix(mdb_redis): handle nil Redis config for Valkey clusters

### DIFF
--- a/.changes/unreleased/BUG_FIXES-20251128-203000.yaml
+++ b/.changes/unreleased/BUG_FIXES-20251128-203000.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: 'mdb_redis: fix nil pointer dereference when reading Valkey clusters'
+time: 2025-11-28T20:30:00Z

--- a/yandex/mdb_redis_structures.go
+++ b/yandex/mdb_redis_structures.go
@@ -203,6 +203,10 @@ func extractRedisConfig(cc *redis.ClusterConfig) redisConfig {
 	res := redisConfig{
 		version: cc.Version,
 	}
+	// Fix for Valkey: cc.Redis can be nil for Valkey clusters
+	if cc.Redis == nil || cc.Redis.EffectiveConfig == nil {
+		return res  // Return minimal config for Valkey
+	}
 	c := cc.Redis.EffectiveConfig
 	res.maxmemoryPolicy = c.GetMaxmemoryPolicy().String()
 	res.timeout = c.GetTimeout().GetValue()

--- a/yandex/mdb_redis_structures_test.go
+++ b/yandex/mdb_redis_structures_test.go
@@ -729,3 +729,17 @@ func TestSortRedisHostsSharded(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractRedisConfig_NilRedis tests that extractRedisConfig handles nil Redis config
+// This occurs with Valkey clusters where ClusterConfig.Redis is nil
+func TestExtractRedisConfig_NilRedis(t *testing.T) {
+	cc := &redis.ClusterConfig{
+		Version: "7.2-valkey",
+		Redis:   nil, // Valkey clusters may have nil Redis config
+	}
+
+	result := extractRedisConfig(cc)
+
+	require.Equal(t, "7.2-valkey", result.version)
+	require.Equal(t, "", result.maxmemoryPolicy)
+}


### PR DESCRIPTION
## Description
  Fixes nil pointer dereference crash when reading Valkey clusters (e.g., `7.2-valkey`, `8.1-valkey`).

  ## Problem
  When using Valkey-based Redis clusters in Yandex Cloud, the provider crashes with:
  panic: runtime error: invalid memory address or nil pointer dereference
  goroutine 149 [running]:
  github.com/yandex-cloud/terraform-provider-yandex/yandex.extractRedisConfig(0x0?)
      yandex/mdb_redis_structures.go:201 +0x199

  ## Root Cause
  For Valkey clusters, `ClusterConfig.Redis` can be nil. The code accesses `cc.Redis.EffectiveConfig` without checking if `cc.Redis` is nil first.

  ## Solution
  Add nil check before accessing `cc.Redis.EffectiveConfig`:
  ```go
  if cc.Redis == nil || cc.Redis.EffectiveConfig == nil {
      return res
  }

  Testing

  - Added unit test TestExtractRedisConfig_NilRedis
  - Manually tested with Valkey 7.2 cluster on Yandex Cloud

  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  ```


Fixes nil pointer dereference in extractRedisConfig when reading Valkey clusters. The cc.Redis field can be nil for Valkey-based clusters (e.g., 7.2-valkey, 8.1-valkey), causing a crash when accessing cc.Redis.EffectiveConfig.

This change adds a nil check before accessing EffectiveConfig, returning a minimal config with just the version for Valkey clusters.

Fixes panic:
  panic: runtime error: invalid memory address or nil pointer dereference
  goroutine ... [running]:
  github.com/yandex-cloud/terraform-provider-yandex/yandex.extractRedisConfig
      yandex/mdb_redis_structures.go:201