### PR TITLE
fix: deploy severity level

### DIFF
--- a/.changes/unreleased/BUG FIXES-20251222-200736.yaml
+++ b/.changes/unreleased/BUG FIXES-20251222-200736.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: change severity level for yandex function and serverless container
+time: 2025-12-22T20:07:36.738832+03:00

--- a/yandex/resource_yandex_function.go
+++ b/yandex/resource_yandex_function.go
@@ -547,7 +547,7 @@ func resourceYandexFunctionDiagsFromCreateVersionError(err error) diag.Diagnosti
 		return nil
 	}
 	return diag.Diagnostics{diag.Diagnostic{
-		Severity: diag.Warning,
+		Severity: diag.Error,
 		Summary:  "Failed to create version for Yandex Cloud Function",
 		Detail: "Error while requesting API to create version for Yandex Cloud Function. " +
 			"After resolving following issues apply resource again to create version for Yandex Cloud Function:\n" +

--- a/yandex/resource_yandex_serverless_container.go
+++ b/yandex/resource_yandex_serverless_container.go
@@ -562,7 +562,7 @@ func resourceYandexServerlessContainerDiagsFromDeployRevisionError(err error) di
 		return nil
 	}
 	return diag.Diagnostics{diag.Diagnostic{
-		Severity: diag.Warning,
+		Severity: diag.Error,
 		Summary:  "Failed to deploy revision for Yandex Cloud Container",
 		Detail: "Error while requesting API to deploy revision for Yandex Cloud Container. " +
 			"After resolving following issues apply resource again to deploy revision for Yandex Cloud Container:\n" +


### PR DESCRIPTION
# Problem

If there are problems with deploying a revision for Yandex Cloud Container or creating a version for a Yandex Cloud Function then any CI/CD pipeline completes successfully, since the exit code of terraform apply is 0.

# Solution
Set the `Error` severity level instead of `Warning`.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru