### PR TITLE
[SERVERLESS-5945] fix function trigger timer container without retry

### DIFF
--- a/yandex/resource_yandex_function_trigger.go
+++ b/yandex/resource_yandex_function_trigger.go
@@ -820,19 +820,13 @@ func constructRule(d *schema.ResourceData) (*triggers.Trigger_Rule, error) {
 			timer.Payload = v.(string)
 		}
 
-		if retrySettings != nil || dlqSettings != nil {
-			if invokeType == "function" {
-				timer.Action = &triggers.Trigger_Timer_InvokeFunctionWithRetry{
-					InvokeFunctionWithRetry: getInvokeFunctionWithRetry(),
-				}
-			} else if invokeType == "container" {
-				timer.Action = &triggers.Trigger_Timer_InvokeContainerWithRetry{
-					InvokeContainerWithRetry: getInvokeContainerWithRetry(),
-				}
+		if invokeType == "function" {
+			timer.Action = &triggers.Trigger_Timer_InvokeFunctionWithRetry{
+				InvokeFunctionWithRetry: getInvokeFunctionWithRetry(),
 			}
-		} else {
-			timer.Action = &triggers.Trigger_Timer_InvokeFunction{
-				InvokeFunction: getInvokeFunctionOnce(),
+		} else if invokeType == "container" {
+			timer.Action = &triggers.Trigger_Timer_InvokeContainerWithRetry{
+				InvokeContainerWithRetry: getInvokeContainerWithRetry(),
 			}
 		}
 


### PR DESCRIPTION
Если попытаться создать триггер таймер с вызовом контейнера, но не указать retrySetting, то в облако будет отправлен запрос на создание триггер таймера с вызовом фукнции (не контейнера), а поскольку ни одно поле для функции не заполнено, то в ответ будет ошибка "Validation failed: rule.timer.invoke_function.function_id: Field is required". У пользователя недоумение, почему триггер на вызов контейнера, а ошибка про функцию - потому что терраформ провайдер создает триггер на функцию, а не на контейнер.