### PR TITLE
Populate `subnet_ids` on read for `yandex_mdb_kafka_cluster`

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260605-075734.yaml
+++ b/.changes/unreleased/BUG FIXES-20260605-075734.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: 'mdb_kafka: populate `subnet_ids` on read so `yandex_mdb_kafka_cluster` no longer shows a permanent diff after import'
+time: 2026-06-05T07:57:34+03:00

--- a/yandex/data_source_yandex_mdb_kafka_cluster.go
+++ b/yandex/data_source_yandex_mdb_kafka_cluster.go
@@ -83,6 +83,7 @@ func dataSourceYandexMDBKafkaCluster() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: common.ResourceDescriptions["subnet_ids"],
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"topic": {
@@ -229,6 +230,10 @@ func dataSourceYandexMDBKafkaClusterRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 	if err := d.Set("host", flattenKafkaHosts(hosts)); err != nil {
+		return err
+	}
+
+	if err := d.Set("subnet_ids", flattenKafkaClusterSubnets(hosts)); err != nil {
 		return err
 	}
 

--- a/yandex/mdb_kafka_structures.go
+++ b/yandex/mdb_kafka_structures.go
@@ -1152,6 +1152,51 @@ func flattenKafkaHosts(hosts []*kafka.Host) *schema.Set {
 	return result
 }
 
+func flattenKafkaClusterSubnets(hosts []*kafka.Host) []string {
+	subnets := make([]string, 0, len(hosts))
+	seen := make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		subnetID := host.GetSubnetId()
+		if subnetID == "" {
+			continue
+		}
+		if _, ok := seen[subnetID]; ok {
+			continue
+		}
+		seen[subnetID] = struct{}{}
+		subnets = append(subnets, subnetID)
+	}
+	return subnets
+}
+
+func orderKafkaSubnetsByState(stateSubnets, actualSubnets []string) []string {
+	actual := make(map[string]struct{}, len(actualSubnets))
+	for _, id := range actualSubnets {
+		actual[id] = struct{}{}
+	}
+
+	ordered := make([]string, 0, len(actualSubnets))
+	used := make(map[string]struct{}, len(actualSubnets))
+	for _, id := range stateSubnets {
+		if _, ok := actual[id]; !ok {
+			continue
+		}
+		if _, dup := used[id]; dup {
+			continue
+		}
+		used[id] = struct{}{}
+		ordered = append(ordered, id)
+	}
+	for _, id := range actualSubnets {
+		if _, ok := used[id]; ok {
+			continue
+		}
+		used[id] = struct{}{}
+		ordered = append(ordered, id)
+	}
+	return ordered
+}
+
 func kafkaUsersPasswords(users []*kafka.UserSpec) map[string]string {
 	result := map[string]string{}
 	for _, u := range users {

--- a/yandex/mdb_kafka_structures_test.go
+++ b/yandex/mdb_kafka_structures_test.go
@@ -3,6 +3,7 @@ package yandex
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/mdb/kafka/v1"
 	"sort"
 	"testing"
 )
@@ -93,6 +94,99 @@ func Test_parseKafkaPermissionAllowHosts(t *testing.T) {
 			sort.Strings(result)
 			sort.Strings(tt.want)
 			assert.Equalf(t, tt.want, result, "parseKafkaPermissionAllowHosts(%v)", tt.args.allowHosts)
+		})
+	}
+}
+
+func Test_flattenKafkaClusterSubnets(t *testing.T) {
+	tests := []struct {
+		name  string
+		hosts []*kafka.Host
+		want  []string
+	}{
+		{
+			name:  "nil hosts",
+			hosts: nil,
+			want:  []string{},
+		},
+		{
+			name: "single host",
+			hosts: []*kafka.Host{
+				{SubnetId: "subnet-a"},
+			},
+			want: []string{"subnet-a"},
+		},
+		{
+			name: "deduplicates and preserves first-seen order",
+			hosts: []*kafka.Host{
+				{SubnetId: "subnet-b"},
+				{SubnetId: "subnet-a"},
+				{SubnetId: "subnet-b"},
+				{SubnetId: "subnet-c"},
+				{SubnetId: "subnet-a"},
+			},
+			want: []string{"subnet-b", "subnet-a", "subnet-c"},
+		},
+		{
+			name: "skips empty subnet ids",
+			hosts: []*kafka.Host{
+				{SubnetId: ""},
+				{SubnetId: "subnet-a"},
+				{SubnetId: ""},
+			},
+			want: []string{"subnet-a"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := flattenKafkaClusterSubnets(tt.hosts)
+			assert.Equalf(t, tt.want, got, "flattenKafkaClusterSubnets(%v)", tt.hosts)
+		})
+	}
+}
+
+func Test_orderKafkaSubnetsByState(t *testing.T) {
+	tests := []struct {
+		name          string
+		stateSubnets  []string
+		actualSubnets []string
+		want          []string
+	}{
+		{
+			name:          "empty state keeps actual order",
+			stateSubnets:  nil,
+			actualSubnets: []string{"subnet-a", "subnet-b"},
+			want:          []string{"subnet-a", "subnet-b"},
+		},
+		{
+			name:          "preserves state order when the set is unchanged",
+			stateSubnets:  []string{"subnet-c", "subnet-a", "subnet-b"},
+			actualSubnets: []string{"subnet-a", "subnet-b", "subnet-c"},
+			want:          []string{"subnet-c", "subnet-a", "subnet-b"},
+		},
+		{
+			name:          "drops subnets no longer present",
+			stateSubnets:  []string{"subnet-a", "subnet-gone", "subnet-b"},
+			actualSubnets: []string{"subnet-b", "subnet-a"},
+			want:          []string{"subnet-a", "subnet-b"},
+		},
+		{
+			name:          "appends new subnets after the known ones",
+			stateSubnets:  []string{"subnet-b", "subnet-a"},
+			actualSubnets: []string{"subnet-a", "subnet-b", "subnet-new"},
+			want:          []string{"subnet-b", "subnet-a", "subnet-new"},
+		},
+		{
+			name:          "deduplicates repeated state entries",
+			stateSubnets:  []string{"subnet-a", "subnet-a", "subnet-b"},
+			actualSubnets: []string{"subnet-a", "subnet-b"},
+			want:          []string{"subnet-a", "subnet-b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := orderKafkaSubnetsByState(tt.stateSubnets, tt.actualSubnets)
+			assert.Equalf(t, tt.want, got, "orderKafkaSubnetsByState(%v, %v)", tt.stateSubnets, tt.actualSubnets)
 		})
 	}
 }

--- a/yandex/resource_yandex_mdb_kafka_cluster.go
+++ b/yandex/resource_yandex_mdb_kafka_cluster.go
@@ -90,6 +90,7 @@ func resourceYandexMDBKafkaCluster() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: common.ResourceDescriptions["subnet_ids"],
 				Optional:    true,
+				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"topic": {
@@ -1013,6 +1014,12 @@ func resourceYandexMDBKafkaClusterRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 	if err := d.Set("host", flattenKafkaHosts(hosts)); err != nil {
+		return err
+	}
+
+	actualSubnets := flattenKafkaClusterSubnets(hosts)
+	stateSubnets := expandStringSlice(d.Get("subnet_ids").([]interface{}))
+	if err := d.Set("subnet_ids", orderKafkaSubnetsByState(stateSubnets, actualSubnets)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The Kafka cluster API doesn't return subnets on the cluster object, only on each host, so `subnet_ids` was never written to state on read. After import or refresh the field stayed empty and produced a permanent in-place diff; the data source had the same gap.

Derive `subnet_ids` from the cluster hosts on read and mark the attribute as Computed so clusters relying on auto-assigned subnets don't show a diff when the field is omitted.

Fixes #481

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en