### PR TITLE
dns: fix perpetual diff for yandex_dns_recordset TXT records over 255 bytes

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260615-165642.yaml
+++ b/.changes/unreleased/BUG FIXES-20260615-165642.yaml
@@ -1,0 +1,4 @@
+kind: BUG FIXES
+body: 'dns: fix perpetual diff for yandex_dns_recordset TXT records longer than 255
+  bytes'
+time: 2026-06-15T16:56:42.142684+03:00

--- a/yandex/dns_recordset_txt.go
+++ b/yandex/dns_recordset_txt.go
@@ -1,0 +1,93 @@
+package yandex
+
+import "strings"
+
+// canonicalizeTXTRecordValue joins a TXT value only when its segmentation
+// matches the DNS API's 255-byte chunking of a longer character-string.
+// Intentional shorter segments, escapes, and malformed input are preserved.
+func canonicalizeTXTRecordValue(s string) string {
+	if len(s) == 0 || s[0] != '"' {
+		return s
+	}
+
+	type segment struct {
+		content    string
+		decodedLen int
+	}
+
+	segments := make([]segment, 0, 2)
+	i := 0
+	for {
+		if i >= len(s) || s[i] != '"' {
+			return s
+		}
+		i++
+		contentStart := i
+		decodedLen := 0
+
+		for i < len(s) {
+			switch s[i] {
+			case '\\':
+				if i+1 >= len(s) {
+					return s
+				}
+				decodedLen++
+				if s[i+1] >= '0' && s[i+1] <= '9' {
+					if i+3 >= len(s) ||
+						s[i+2] < '0' || s[i+2] > '9' ||
+						s[i+3] < '0' || s[i+3] > '9' {
+						return s
+					}
+					escapedByte := int(s[i+1]-'0')*100 + int(s[i+2]-'0')*10 + int(s[i+3]-'0')
+					if escapedByte > 255 {
+						return s
+					}
+					i += 4
+					continue
+				}
+				i += 2
+			case '"':
+				segments = append(segments, segment{content: s[contentStart:i], decodedLen: decodedLen})
+				i++
+				goto segmentClosed
+			default:
+				decodedLen++
+				i++
+			}
+		}
+		return s
+
+	segmentClosed:
+		separatorStart := i
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\r' || s[i] == '\n') {
+			i++
+		}
+		if i == len(s) {
+			if i != separatorStart {
+				return s
+			}
+			break
+		}
+	}
+
+	if len(segments) < 2 {
+		return s
+	}
+	for i, segment := range segments {
+		if segment.decodedLen == 0 || segment.decodedLen > 255 {
+			return s
+		}
+		if i < len(segments)-1 && segment.decodedLen != 255 {
+			return s
+		}
+	}
+
+	var joined strings.Builder
+	joined.Grow(len(s))
+	joined.WriteByte('"')
+	for _, segment := range segments {
+		joined.WriteString(segment.content)
+	}
+	joined.WriteByte('"')
+	return joined.String()
+}

--- a/yandex/resource_yandex_dns_recordset.go
+++ b/yandex/resource_yandex_dns_recordset.go
@@ -77,7 +77,9 @@ func resourceYandexDnsRecordSet() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringLenBetween(1, 1024),
 				},
-				Set: schema.HashString,
+				Set: func(v interface{}) int {
+					return schema.HashString(canonicalizeTXTRecordValue(v.(string)))
+				},
 			},
 		},
 	}
@@ -138,9 +140,15 @@ func resourceYandexDnsRecordSetRead(d *schema.ResourceData, meta interface{}) er
 		return handleNotFoundError(err, d, fmt.Sprintf("DnsRecordSet %s", rsId(d)))
 	}
 
-	d.Set("description", rs.Description)
-	d.Set("ttl", int(rs.Ttl))
-	d.Set("data", convertStringArrToInterface(rs.Data))
+	if err := d.Set("description", rs.Description); err != nil {
+		return fmt.Errorf("failed to set DNS RecordSet description: %w", err)
+	}
+	if err := d.Set("ttl", int(rs.Ttl)); err != nil {
+		return fmt.Errorf("failed to set DNS RecordSet TTL: %w", err)
+	}
+	if err := d.Set("data", convertStringArrToInterface(rs.Data)); err != nil {
+		return fmt.Errorf("failed to set DNS RecordSet data: %w", err)
+	}
 
 	return nil
 }

--- a/yandex/resource_yandex_dns_recordset_test.go
+++ b/yandex/resource_yandex_dns_recordset_test.go
@@ -3,12 +3,15 @@ package yandex
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/yandex-cloud/go-genproto/yandex/cloud/dns/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestAccDNSRecordSet_basic(t *testing.T) {
@@ -21,7 +24,7 @@ func TestAccDNSRecordSet_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVPCAddressDestroy,
+		CheckDestroy: testAccCheckDNSRecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDNSRecordSetBasic(zoneName, fqdn),
@@ -54,7 +57,7 @@ func TestAccDNSRecordSet_short(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVPCAddressDestroy,
+		CheckDestroy: testAccCheckDNSRecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDNSRecordSetBasicShort(zoneName, fqdn),
@@ -85,7 +88,7 @@ func TestAccDNSRecordSet_zoneChange(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVPCAddressDestroy,
+		CheckDestroy: testAccCheckDNSRecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDNSRecordSetBasic(zoneName, fqdn),
@@ -125,7 +128,7 @@ func TestAccDNSRecordSet_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckVPCAddressDestroy,
+		CheckDestroy: testAccCheckDNSRecordSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDNSRecordSetBasic(zoneName, fqdn),
@@ -318,4 +321,131 @@ resource "yandex_dns_recordset" "rs2" {
   data        = ["192.168.0.10"]
 }
 `, name, fqdn)
+}
+
+func testAccCheckDNSRecordSetDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	sdk := getSDK(config)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "yandex_dns_recordset" {
+			continue
+		}
+
+		_, err := sdk.DNS().DnsZone().GetRecordSet(context.Background(), &dns.GetDnsZoneRecordSetRequest{
+			DnsZoneId: rs.Primary.Attributes["zone_id"],
+			Name:      rs.Primary.Attributes["name"],
+			Type:      rs.Primary.Attributes["type"],
+		})
+
+		if err == nil {
+			return fmt.Errorf("DNS RecordSet still exists: %s/%s/%s",
+				rs.Primary.Attributes["zone_id"],
+				rs.Primary.Attributes["name"],
+				rs.Primary.Attributes["type"])
+		}
+		if status.Code(err) != codes.NotFound {
+			return fmt.Errorf("failed to check DNS RecordSet destruction %s/%s/%s: %w",
+				rs.Primary.Attributes["zone_id"],
+				rs.Primary.Attributes["name"],
+				rs.Primary.Attributes["type"],
+				err)
+		}
+	}
+
+	return nil
+}
+
+// longDKIMTXTValue is a DKIM TXT value > 255 bytes; the Yandex DNS API will return it
+// split into two quoted character-strings separated by " ".
+const longDKIMTXTValue = `"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2a2rwplBQLF29amygykEMmYz0+Kcj3bKBp29OoVXFBFAQFbnScEBInGGaVFMBMPEBiMrJNmvRQKMn/YFTfDH9MWbEPHFY2XnHUHZQjKuHUkXqMpjIBXNBLxkNVRKEXBRGGBOEIhLBaKfM5N1LN7O9S8GkMbH3YUgBOK0NOZC0r1MFLgLXuJDVXg+GhFJfNIwzYHqHFLhRCrEmGIzAGxFmiqkjp8VQiMerGRilHolTuVFNkfVs/t1tTRTgGzXAx7ClZHOuKX/k9U/KEIlN1VEWQP4lcLqMqZ0i5GxrRFyOPqBBFbJKsRr40D5EQFKUEJ"`
+
+// longDKIMTXTValue2 differs from longDKIMTXTValue by one character (QLF→QlF) to exercise update/delete semantics.
+const longDKIMTXTValue2 = `"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2a2rwplBQlF29amygykEMmYz0+Kcj3bKBp29OoVXFBFAQFbnScEBInGGaVFMBMPEBiMrJNmvRQKMn/YFTfDH9MWbEPHFY2XnHUHZQjKuHUkXqMpjIBXNBLxkNVRKEXBRGGBOEIhLBaKfM5N1LN7O9S8GkMbH3YUgBOK0NOZC0r1MFLgLXuJDVXg+GhFJfNIwzYHqHFLhRCrEmGIzAGxFmiqkjp8VQiMerGRilHolTuVFNkfVs/t1tTRTgGzXAx7ClZHOuKX/k9U/KEIlN1VEWQP4lcLqMqZ0i5GxrRFyOPqBBFbJKsRr40D5EQFKUEJ"`
+
+func testAccDNSRecordSetLongTXT(dnsZoneName, dnsZoneDescription, recordName, txtValue string) string {
+	return fmt.Sprintf(`
+resource "yandex_dns_zone" "zone1" {
+  name        = %[1]q
+  description = %[2]q
+  zone        = "%[1]s.dnstest.test."
+}
+
+resource "yandex_dns_recordset" "rs1" {
+  zone_id = yandex_dns_zone.zone1.id
+  name    = %[3]q
+  type    = "TXT"
+  ttl     = 300
+  data    = [%[4]q]
+}
+`, dnsZoneName, dnsZoneDescription, recordName, txtValue)
+}
+
+func TestAccDNSRecordSet_longTXT(t *testing.T) {
+	t.Parallel()
+
+	var rs1, rs2 dns.RecordSet
+
+	dnsZoneName := fmt.Sprintf("zone-txt-%s", acctest.RandString(10))
+	dnsZoneDescription := "Test zone for long TXT record"
+	recordName := fmt.Sprintf("_domainkey.test%s.%s.dnstest.test.", acctest.RandString(6), dnsZoneName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSRecordSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordSetLongTXT(dnsZoneName, dnsZoneDescription, recordName, longDKIMTXTValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSRecordSetExists("yandex_dns_recordset.rs1", &rs1),
+					// Assert raw API returned a split value (contains `" "` boundary).
+					func(s *terraform.State) error {
+						if len(rs1.Data) == 0 {
+							return fmt.Errorf("expected API to return split TXT data, got no values")
+						}
+						if !strings.Contains(rs1.Data[0], "\" \"") {
+							return fmt.Errorf("expected API to return split TXT data (containing '\" \"'), got: %q", rs1.Data[0])
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config:             testAccDNSRecordSetLongTXT(dnsZoneName, dnsZoneDescription, recordName, longDKIMTXTValue),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testAccDNSRecordSetLongTXT(dnsZoneName, dnsZoneDescription, recordName, longDKIMTXTValue2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSRecordSetExists("yandex_dns_recordset.rs1", &rs2),
+				),
+			},
+			{
+				Config:             testAccDNSRecordSetLongTXT(dnsZoneName, dnsZoneDescription, recordName, longDKIMTXTValue2),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:            "yandex_dns_recordset.rs1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data"},
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected one imported DNS RecordSet state, got %d", len(states))
+					}
+
+					for key, value := range states[0].Attributes {
+						if strings.HasPrefix(key, "data.") && key != "data.#" && canonicalizeTXTRecordValue(value) == longDKIMTXTValue2 {
+							return nil
+						}
+					}
+
+					return fmt.Errorf("expected imported TXT data equivalent to %q, got %#v", longDKIMTXTValue2, states[0].Attributes)
+				},
+			},
+		},
+	})
 }

--- a/yandex/resource_yandex_dns_recordset_unit_test.go
+++ b/yandex/resource_yandex_dns_recordset_unit_test.go
@@ -1,0 +1,204 @@
+package yandex
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	terraform2 "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeTXTRecordValue(t *testing.T) {
+	fullChunk := strings.Repeat("a", 255)
+	secondFullChunk := strings.Repeat("b", 255)
+	escapedFullChunk := strings.Repeat("a", 254) + `\123`
+	escapedQuoteFullChunk := strings.Repeat("a", 254) + `\"`
+	oneDigitEscapeFullChunk := strings.Repeat("a", 254) + `\1`
+	twoDigitEscapeFullChunk := strings.Repeat("a", 253) + `\12`
+	outOfRangeEscapeFullChunk := strings.Repeat("a", 254) + `\256`
+	utf8FullChunk := strings.Repeat("a", 253) + "é"
+	overlongFinalChunk := strings.Repeat("b", 256)
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "joins API split after 255 decoded bytes",
+			input: `"` + fullChunk + `" "tail"`,
+			want:  `"` + fullChunk + `tail"`,
+		},
+		{
+			name:  "joins multiple full API chunks",
+			input: `"` + fullChunk + `" "` + secondFullChunk + `" "tail"`,
+			want:  `"` + fullChunk + secondFullChunk + `tail"`,
+		},
+		{
+			name:  "numeric escape counts as one decoded byte",
+			input: `"` + escapedFullChunk + `" "tail"`,
+			want:  `"` + escapedFullChunk + `tail"`,
+		},
+		{
+			name:  "escaped quote counts as one decoded byte",
+			input: `"` + escapedQuoteFullChunk + `" "tail"`,
+			want:  `"` + escapedQuoteFullChunk + `tail"`,
+		},
+		{
+			name:  "join cannot complete one-digit numeric escape",
+			input: `"` + oneDigitEscapeFullChunk + `" "23tail"`,
+			want:  `"` + oneDigitEscapeFullChunk + `" "23tail"`,
+		},
+		{
+			name:  "join cannot complete two-digit numeric escape",
+			input: `"` + twoDigitEscapeFullChunk + `" "3tail"`,
+			want:  `"` + twoDigitEscapeFullChunk + `" "3tail"`,
+		},
+		{
+			name:  "out-of-range numeric escape remains unchanged",
+			input: `"` + outOfRangeEscapeFullChunk + `" "tail"`,
+			want:  `"` + outOfRangeEscapeFullChunk + `" "tail"`,
+		},
+		{
+			name:  "UTF-8 payload is counted in bytes",
+			input: `"` + utf8FullChunk + `" "tail"`,
+			want:  `"` + utf8FullChunk + `tail"`,
+		},
+		{
+			name:  "short intentional segments remain distinct",
+			input: `"a" "b"`,
+			want:  `"a" "b"`,
+		},
+		{
+			name:  "adjacent short segments remain distinct",
+			input: `"a""b"`,
+			want:  `"a""b"`,
+		},
+		{
+			name:  "empty first segment remains distinct",
+			input: `"" "a"`,
+			want:  `"" "a"`,
+		},
+		{
+			name:  "empty final segment is not an API split",
+			input: `"` + fullChunk + `" ""`,
+			want:  `"` + fullChunk + `" ""`,
+		},
+		{
+			name:  "overlong final segment is not an API split",
+			input: `"` + fullChunk + `" "` + overlongFinalChunk + `"`,
+			want:  `"` + fullChunk + `" "` + overlongFinalChunk + `"`,
+		},
+		{
+			name:  "trailing whitespace is preserved",
+			input: `"` + fullChunk + `" "tail" `,
+			want:  `"` + fullChunk + `" "tail" `,
+		},
+		{
+			name:  "single long segment remains unchanged",
+			input: `"` + strings.Repeat("a", 600) + `"`,
+			want:  `"` + strings.Repeat("a", 600) + `"`,
+		},
+		{
+			name:  "unquoted value remains unchanged",
+			input: "v=spf1 include:_spf.google.com ~all",
+			want:  "v=spf1 include:_spf.google.com ~all",
+		},
+		{
+			name:  "trailing junk remains unchanged",
+			input: `"foo" bar`,
+			want:  `"foo" bar`,
+		},
+		{
+			name:  "unterminated value remains unchanged",
+			input: `"foo`,
+			want:  `"foo`,
+		},
+		{
+			name:  "dangling escape remains unchanged",
+			input: `"foo\`,
+			want:  `"foo\`,
+		},
+		{
+			name:  "empty string remains unchanged",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := canonicalizeTXTRecordValue(tt.input)
+			if got != tt.want {
+				t.Errorf("canonicalizeTXTRecordValue(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDNSRecordSetDataSchemaPreservesDistinctQuotedValues(t *testing.T) {
+	dataSchema := resourceYandexDnsRecordSet().Schema["data"]
+	values := schema.NewSet(dataSchema.Set, []interface{}{`"a" "b"`, `"ab"`})
+
+	if values.Len() != 2 {
+		t.Fatalf("DNS record data set contains %d values, want 2 distinct values", values.Len())
+	}
+}
+
+func TestDNSRecordSetEquivalentTXTRepresentationsDoNotProduceDiffAfterRead(t *testing.T) {
+	fullChunk := strings.Repeat("a", 255)
+	joinedValue := `"` + fullChunk + `tail"`
+	segmentedValue := `"` + fullChunk + `" "tail"`
+
+	tests := []struct {
+		name            string
+		configuredValue string
+	}{
+		{
+			name:            "joined configuration",
+			configuredValue: joinedValue,
+		},
+		{
+			name:            "explicitly segmented configuration",
+			configuredValue: segmentedValue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := resourceYandexDnsRecordSet()
+			config := map[string]interface{}{
+				"zone_id": "test-zone-id",
+				"name":    "test.example.",
+				"type":    "TXT",
+				"ttl":     300,
+				"data":    []interface{}{tt.configuredValue},
+			}
+			resourceData := schema.TestResourceDataRaw(t, resource.Schema, config)
+			resourceData.SetId("test-zone-id/test.example./TXT")
+
+			err := resourceData.Set("data", []interface{}{segmentedValue})
+			require.NoError(t, err)
+			require.Equal(t, []interface{}{segmentedValue}, resourceData.Get("data").(*schema.Set).List())
+
+			diff, err := schema.InternalMap(resource.Schema).Diff(
+				context.Background(),
+				resourceData.State(),
+				terraform2.NewResourceConfigRaw(config),
+				nil,
+				nil,
+				false,
+			)
+			require.NoError(t, err)
+			require.Nil(t, diff)
+		})
+	}
+}
+
+func TestDNSRecordSetDataSchemaPreservesOrdinaryValueHash(t *testing.T) {
+	dataSchema := resourceYandexDnsRecordSet().Schema["data"]
+	value := "192.0.2.1"
+
+	require.Equal(t, schema.HashString(value), dataSchema.Set(value))
+}


### PR DESCRIPTION
This PR fixes the perpetual diff for `yandex_dns_recordset` TXT records longer than 255 bytes.

## Problem

RFC 1035 limits each TXT `<character-string>` to 255 bytes. Yandex Cloud DNS returns a longer TXT payload as adjacent quoted segments, while Terraform configurations commonly declare the same payload as one quoted value. Because `data` is a `TypeSet`, the two serializations previously received different element hashes and every subsequent `terraform plan` reported a change.

Normalizing all API responses into the joined form is not sufficient: a configuration that explicitly uses a 255-byte segment would then get the inverse perpetual diff.

## Fix

- Hash TXT set elements using their canonical value when the segments match the API chunking shape: every non-final segment is exactly 255 decoded bytes and the final segment is non-empty and at most 255 bytes.
- Keep the API value written by `Read` instead of forcing either serialization into state.
- Preserve unquoted, malformed, overlong, empty, and intentionally shorter segmented values unchanged.
- Propagate `ResourceData.Set` errors from `Read` instead of silently leaving incomplete state.
- Use the DNS record set destroy checker in all DNS record set acceptance tests.

Joined configuration, explicitly segmented configuration, refreshed state, and imported state now converge without rewriting user configuration or requiring manual state edits.

## Tests

- Unit coverage for joined and explicitly segmented configuration, multi-chunk values, escapes, UTF-8 byte lengths, malformed input, trailing whitespace, and distinct short segments.
- `go test -race ./yandex -run 'TestDNSRecordSet(EquivalentTXTRepresentationsDoNotProduceDiffAfterRead|DataSchemaPreservesOrdinaryValueHash|TXT)' -count=1`
- `go test ./yandex -count=1` (735 tests passed)
- `go build ./...`
- `TestAccDNSRecordSet_longTXT` against Yandex Cloud: create, stable plan, update, stable plan, import, and cleanup all passed.

A Changie bug-fix entry is included under `.changes/unreleased/`.

Fixes #506.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en