### PR TITLE
kafka: fix disk_size_limit description, the value is set in gigabytes…

### DIFF
--- a/yandex/resource_yandex_mdb_kafka_cluster.go
+++ b/yandex/resource_yandex_mdb_kafka_cluster.go
@@ -270,7 +270,7 @@ func resourceYandexMDBKafkaClusterConfig() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"disk_size_limit": {
 							Type:        schema.TypeInt,
-							Description: "Maximum possible size of disk in bytes.",
+							Description: "The overall maximum for disk size (GB) that limits all autoscaling iterations.",
 							Required:    true,
 						},
 						"planned_usage_threshold": {


### PR DESCRIPTION
Обновлено описание `disk_size_limit`: значение задаётся в гигабайтах, а не в байтах.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru

### Проблема

Описание поля `config.disk_size_autoscaling.disk_size_limit` у `yandex_mdb_kafka_cluster` указывает что размер диска измеряется в байтах:

```go
"disk_size_limit": {
    Type:        schema.TypeInt,
    Description: "Maximum possible size of disk in bytes.",
    Required:    true,
},
```

https://github.com/yandex-cloud/terraform-provider-yandex/blob/master/yandex/resource_yandex_mdb_kafka_cluster.go#L271-L275

На деле провайдер ждёт гигабайты и в коде сам преобразует их в байты

- запись: `out.DiskSizeLimit = toBytes(v.(int))` — https://github.com/yandex-cloud/terraform-provider-yandex/blob/master/yandex/mdb_kafka_structures.go#L594-L596
- чтение: `out["disk_size_limit"] = toGigabytes(p.DiskSizeLimit)` — https://github.com/yandex-cloud/terraform-provider-yandex/blob/master/yandex/mdb_kafka_structures.go#L773

Остальные кластеры MDB в документации указывают поле как гигабайты:

| Ресурс | Описание |
| --- | --- |
| `yandex_mdb_mysql_cluster` | `The overall maximum for disk size (GB) that limits all autoscaling iterations.` |
| `yandex_mdb_mongodb_cluster` | `The overall maximum for disk size (GB) that limits all autoscaling iterations.` |
| `yandex_mdb_postgresql_cluster` | `The overall maximum for disk size that limit all autoscaling iterations. See the documentation for details.` |

### Изменения

Взята формулировка по примеру MySQL и MongoDB

`The overall maximum for disk size (GB) that limits all autoscaling iterations.`

- `yandex/resource_yandex_mdb_kafka_cluster.go` — описание в схеме

Изменение затрагивает только документацию, поведение провайдера прежнее.