### PR TITLE
Honour the caller's context in three IAM updaters

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260902-151959.yaml
+++ b/.changes/unreleased/BUG FIXES-20260902-151959.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: 'iam: service_account, organization and workload_identity_oidc_federation IAM updaters now honour the caller''s context instead of discarding it'
+time: 2026-09-02T15:19:59+05:30

--- a/yandex/iam_organization.go
+++ b/yandex/iam_organization.go
@@ -57,7 +57,7 @@ func (u *OrganizationIamUpdater) SetResourceIamPolicy(ctx context.Context, polic
 		AccessBindings: policy.Bindings,
 	}
 
-	ctx, cancel := context.WithTimeout(u.Config.Context(), yandexOrganizationManagerOrganizationDefaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, yandexOrganizationManagerOrganizationDefaultTimeout)
 	defer cancel()
 
 	op, err := client.SetAccessBindings(ctx, req)

--- a/yandex/iam_service_account.go
+++ b/yandex/iam_service_account.go
@@ -55,7 +55,7 @@ func (u *ServiceAccountIamUpdater) SetResourceIamPolicy(ctx context.Context, pol
 		AccessBindings: policy.Bindings,
 	}
 
-	ctx, cancel := context.WithTimeout(u.Config.Context(), yandexIAMServiceAccountDefaultTimeout)
+	ctx, cancel := context.WithTimeout(ctx, yandexIAMServiceAccountDefaultTimeout)
 	defer cancel()
 
 	op, err := client.SetAccessBindings(ctx, req)

--- a/yandex/iam_workload_identity_oidc_federation.go
+++ b/yandex/iam_workload_identity_oidc_federation.go
@@ -54,7 +54,7 @@ func (u *WorkloadIdentityOidcFederationIamUpdater) SetResourceIamPolicy(ctx cont
 		AccessBindings: policy.Bindings,
 	}
 
-	ctx, cancel := context.WithTimeout(u.Config.Context(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
 	client := oidcsdk.NewFederationClient(u.Config.SDK)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## The problem

Three IAM updaters overwrite the `ctx` argument before reading it:

```go
func (u *ServiceAccountIamUpdater) SetResourceIamPolicy(ctx context.Context, policy *Policy) error {
	...
	ctx, cancel := context.WithTimeout(u.Config.Context(), yandexIAMServiceAccountDefaultTimeout)
```

The timeout is derived from `u.Config.Context()` rather than the incoming `ctx`, so the caller's cancellation, deadline and values are discarded. Terraform propagates interrupts through that context, and these three calls cannot see it. `staticcheck` reports it as SA4009, "argument ctx is overwritten before first use".

Affected:

- `yandex/iam_service_account.go:58`
- `yandex/iam_organization.go:60`
- `yandex/iam_workload_identity_oidc_federation.go:57`

## Fifteen of the eighteen updaters already pass ctx

Every `iam_*.go` updater builds the same timeout. Counting across the directory, fifteen use `ctx` and three do not:

| | |
|---|---|
| **Uses `ctx`** | iam_cloud, iam_function, iam_folder, iam_group, iam_dns_zone, iam_cm_certificate, iam_lockbox_secret, iam_container_registry, iam_container_repository, iam_kubernetes_cluster, iam_ydb_database, iam_serverless_container, iam_kms_symmetric_key, iam_kms_asymmetric_encryption_key, iam_kms_asymmetric_signature_key |
| **Uses `u.Config.Context()`** | iam_service_account, iam_organization, iam_workload_identity_oidc_federation |

This change makes the three match the fifteen. The timeout constants are unchanged.

## Verification

`go build ./yandex/...` is clean. A changelog entry is included under `.changes/unreleased/` per CONTRIBUTING.
