### PR TITLE
cdn: allow reads when shielding API is unavailable

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260902-205047.yaml
+++ b/.changes/unreleased/BUG FIXES-20260902-205047.yaml
@@ -1,0 +1,3 @@
+kind: BUG FIXES
+body: 'cdn: allow reading resources when shielding API is unavailable'
+time: 2026-09-02T20:50:47+03:00

--- a/yandex/cdn_helpers.go
+++ b/yandex/cdn_helpers.go
@@ -928,13 +928,20 @@ func getShieldingLocation(ctx context.Context, resourceId string, config *Config
 	resp, err := client.Get(ctx, &cdn.GetShieldingDetailsRequest{
 		ResourceId: resourceId,
 	})
-	if isStatusWithCode(err, codes.NotFound) {
+	if isIgnorableShieldingReadError(err) {
+		if isStatusWithCode(err, codes.Unimplemented) {
+			log.Printf("[WARN] CDN shielding API is unavailable; treating shielding as disabled for resource %q", resourceId)
+		}
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
 	return &resp.LocationId, nil
+}
+
+func isIgnorableShieldingReadError(err error) bool {
+	return isStatusWithCode(err, codes.NotFound) || isStatusWithCode(err, codes.Unimplemented)
 }
 
 func updateShielding(ctx context.Context, d *schema.ResourceData, config *Config) error {

--- a/yandex/cdn_helpers_test.go
+++ b/yandex/cdn_helpers_test.go
@@ -1,0 +1,102 @@
+package yandex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yandex-cloud/go-genproto/yandex/cloud/endpoint"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestGetShieldingLocationWhenServiceIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	grpcServer := grpc.NewServer()
+	endpointServer := &userAgentMockServerAPIEndpoint{}
+	endpoint.RegisterApiEndpointServiceServer(grpcServer, endpointServer)
+
+	listener := localListener(t)
+	endpointServer.endpoints = []*endpoint.ApiEndpoint{
+		{Id: "endpoint", Address: listener.Addr().String()},
+		{Id: "iam", Address: listener.Addr().String()},
+		{Id: "cdn", Address: listener.Addr().String()},
+	}
+	go func() { _ = grpcServer.Serve(listener) }()
+	defer grpcServer.Stop()
+
+	config := Config{
+		Endpoint:  listener.Addr().String(),
+		Token:     "t1.a.b",
+		Plaintext: true,
+	}
+	require.NoError(t, config.initAndValidate(context.Background(), testTerraformVersion, false))
+
+	locationID, err := getShieldingLocation(context.Background(), "resource-id", &config)
+	require.NoError(t, err)
+	assert.Nil(t, locationID)
+}
+
+func TestIsIgnorableShieldingReadError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "shielding is not configured",
+			err:  status.Error(codes.NotFound, "shielding is not configured"),
+			want: true,
+		},
+		{
+			name: "shielding service is not available",
+			err:  status.Error(codes.Unimplemented, "unknown service yandex.cloud.cdn.v1.ShieldingService"),
+			want: true,
+		},
+		{
+			name: "wrapped unimplemented response",
+			err: fmt.Errorf(
+				"reading shielding: %w",
+				status.Error(codes.Unimplemented, "unknown shielding service"),
+			),
+			want: true,
+		},
+		{
+			name: "permission denied",
+			err:  status.Error(codes.PermissionDenied, "permission denied"),
+			want: false,
+		},
+		{
+			name: "service unavailable",
+			err:  status.Error(codes.Unavailable, "service unavailable"),
+			want: false,
+		},
+		{
+			name: "non grpc error",
+			err:  errors.New("network failure"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isIgnorableShieldingReadError(tt.err); got != tt.want {
+				t.Fatalf("isIgnorableShieldingReadError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## Problem

When managing a Cloud CDN resource in Yandex Cloud KZ, `terraform refresh` and `terraform plan` fail even when origin shielding is not configured:

```text
Error: reading shielding: rpc error: code = Unimplemented desc = unknown service yandex.cloud.cdn.v1.ShieldingService
```

This was observed with Terraform 1.5.7 and provider 0.203.0, and the same unconditional shielding read is still present on the current `master` branch.

The CDN resource itself is available in KZ, but the optional `ShieldingService` API is not exposed there. Both the `yandex_cdn_resource` resource and data source call the shared `getShieldingLocation` helper during reads, so an otherwise valid resource cannot be refreshed.

## Change

- Treat exact gRPC `codes.Unimplemented` responses from the shielding read API the same as the existing `codes.NotFound` case: shielding is absent.
- Emit a warning when the read API is unavailable.
- Keep all other errors visible, including `PermissionDenied` and `Unavailable`.
- Leave shielding activate/deactivate operations unchanged. Explicitly configuring shielding in an unsupported environment still fails normally.
- Add a regression test with a local gRPC endpoint where CDN exists but `ShieldingService` is not registered, plus table-driven error-code coverage.
- Add a Changie bug-fix entry.

## Verification

- `make fmtcheck`
- `make changie-lint`
- targeted shielding tests
- `go test ./yandex -count=1 -timeout=60s -parallel=4`
- `go build ./...`

The repository-wide `make test` additionally reaches two existing network-dependent Keybase tests that time out during the TLS handshake. The same failure was reproduced on an unchanged `master`; the modified `yandex` package passes.
